### PR TITLE
reconfigure job, update readme

### DIFF
--- a/.github/workflows/check-image-version.yaml
+++ b/.github/workflows/check-image-version.yaml
@@ -3,7 +3,7 @@ name: Check image version
 on:
   workflow_call:
     inputs:
-      mainRef:
+      branch:
         required: true
         type: string
     secrets:
@@ -21,9 +21,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           
           git fetch origin
-          MIDSTREAM_REF=$(git branch -r | grep 'origin/midstream-v' | awk -F "/" '{print $2}' | tr '\n' ',')
-          echo "MIDSTREAM_REF=$MIDSTREAM_REF" >> $GITHUB_ENV
-          git checkout -B Update-image-version origin/${{ inputs.mainRef }}
+          git checkout -B Update-image-version-${{ inputs.branch }} origin/${{ inputs.branch }}
 
       - name: Check and update images
         working-directory: redhat/overlays
@@ -31,7 +29,7 @@ jobs:
           for image in ubi9/go-toolset ubi9/ubi-minimal; do
             LATEST_SHA=$(skopeo inspect --raw docker://registry.access.redhat.com/$image:latest | jq -r '.manifests[] | select(.platform.architecture == "amd64") .digest')
             CURRENT_SHA=$(grep "registry.access.redhat.com/$image@sha256:" Dockerfile*  | awk '{print $2}' | awk -F '@' '{print $2; exit}')
-              if [ "$CURRENT_SHA" != "$LATEST_SHA" ]; then
+              if [ "$CURRENT_SHA" != "" ] && [ "$CURRENT_SHA" != "$LATEST_SHA" ]; then
                 grep -rl "registry.access.redhat.com/$image@$CURRENT_SHA" . | xargs sed -i "s#registry.access.redhat.com/$image@$CURRENT_SHA#registry.access.redhat.com/$image@$LATEST_SHA#g"
                 git add .
                 git commit -m ":robot: Update $image image ref in Dockerfiles from ${CURRENT_SHA:7:11} to ${LATEST_SHA:7:11}"
@@ -42,22 +40,14 @@ jobs:
       - name: Push changes
         if: ${{ env.IMAGE_UPDATED == 'true' }}
         run: |
-          git push -f origin Update-image-version
-          git checkout ${{ inputs.mainRef }}
-          COMMIT_SHA=$(git log Update-image-version -n 2 --pretty=format:"%H" | tr '\n' ' ')
-          IFS=',' read -ra MID_STR <<< "$MIDSTREAM_REF"
-          for midstream in "${MID_STR[@]}"; do
-            git checkout -B Update-image-version-$midstream origin/$midstream
-            git cherry-pick $COMMIT_SHA
-            git push -f origin Update-image-version-$midstream
-          done
+          git push -f origin Update-image-version-${{ inputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - name: Check for existing pull request
         if: ${{ env.IMAGE_UPDATED == 'true' }}
         run: |
-          openPRs="$(gh pr list --state open -H Update-image-version --json number | jq -r '.[].number' | wc -l)"
+          openPRs="$(gh pr list --state open -H Update-image-version-${{ inputs.branch }} --json number | jq -r '.[].number' | wc -l)"
           echo 'NUM_OPEN_PRS='$openPRs >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
@@ -65,10 +55,6 @@ jobs:
       - name: Create pull request
         if: ${{ env.NUM_OPEN_PRS == 0 && env.IMAGE_UPDATED == 'true' }}
         run: |
-          gh pr create --base ${{ inputs.mainRef }} --head Update-image-version --title ":robot: Update image version in Dockerfiles" --body "This is an automated PR, which updates the Dockerfile versions to their latest versions."
-          IFS=',' read -ra MID_STR <<< "$MIDSTREAM_REF"
-          for midstream in "${MID_STR[@]}"; do
-              gh pr create --base $midstream --head Update-image-version-$midstream --title ":robot: [$midstream] Update image version in Dockerfiles" --body "This is an automated PR, which updates the Dockerfile versions to their latest versions."
-          done
+          gh pr create --base ${{ inputs.branch }} --head Update-image-version-${{ inputs.branch }} --title ":robot: [${{ inputs.branch }}] Update image version in Dockerfiles" --body "This is an automated PR, which updates the Dockerfile versions to their latest versions."
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/README.md
+++ b/README.md
@@ -5,18 +5,20 @@ This repository hosts all reusable GitHub actions utilized by the 'securesign' o
 The current actions included in this repository include:
 
 ### Check image version
-This GitHub Action utilizes skopeo to verify that the images ubi9/go-toolset and ubi9/ubi-minimal are always using the most up-to-date SHA. If they aren't, the action will create a PR to update them in both the main and midstream branches.
+This GitHub Action utilizes skopeo to verify that the images ubi9/go-toolset and ubi9/ubi-minimal are always using the most up-to-date SHA. If they aren't, the action will create a PR to update them in any of the branches specified in the matrix.
 
 #### Usage
 
 ```    
-jobs:
-  check-image-version:
-    uses: securesign/actions/.github/workflows/check-image-version.yaml@main
-    with:
-      mainRef: main  #<--- Required either main or master
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }} #<--- Required 
+check-image-version:
+  uses: securesign/actions/.github/workflows/check-image-version.yaml@main
+  strategy:
+    matrix:
+      branch: [main, midstream-vx-y-z, ....]
+  with:
+    branch: ${{ matrix.branch }}
+  secrets:
+    token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 In order for the action to work correctly there are two settings that need to be changed for the repo.


### PR DESCRIPTION
This pr changes the check-image-version to use a matrix as opposed to a loop, avoids cherry-picking and unnecessary errors because of that 