### PR TITLE
New action: trigger-build-action

### DIFF
--- a/.github/workflows/trigger-konflux-build.yaml
+++ b/.github/workflows/trigger-konflux-build.yaml
@@ -1,0 +1,54 @@
+name: Trigger konflux build
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+        description: 'Branch the action will be run against'
+    secrets:
+      token:
+        required: true
+
+jobs:
+  trigger-konflux-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure git
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+
+          git fetch origin
+          git checkout -B Trigger-Konflux-Pipelines${{ inputs.branch }} origin/${{ inputs.branch }}
+
+      - name: Create Timestamp File
+        run: |
+          day=$(date +'%Y-%m-%d')
+          current_time=$(date +'%H-%M-%S')
+          echo "${day},${current_time}" > trigger-konflux-builds.txt
+
+          git add .
+          git commit -m ":robot: Updated timestamp file to ${day},${current_time}."
+
+      - name: Push changes
+        run: |
+          git push -f origin Trigger-Konflux-Pipelines${{ inputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+
+      - name: Check for existing pull request
+        run: |
+          openPRs="$(gh pr list --state open -H Trigger-Konflux-Pipelines${{ inputs.branch }} --json number | jq -r '.[].number' | wc -l)"
+          echo 'NUM_OPEN_PRS='$openPRs >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+
+      - name: Create pull request
+        if: ${{ env.NUM_OPEN_PRS == 0 }}
+        run: |
+          gh pr create --base ${{ inputs.branch }} --head Trigger-Konflux-Pipelines${{ inputs.branch }} --title ":robot: [${{ inputs.branch }}] Trigger-Konflux-Pipelines" --body "This is an automated PR, that triggers the konflux build pipelines."
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}

--- a/README.md
+++ b/README.md
@@ -29,5 +29,28 @@ In order for the action to work correctly there are two settings that need to be
 1. Actions need to be able to create pull requests (settings -> Actions -> General -> Workflow permissions)
 2. Actions need read and write permissions (settings -> Actions -> General -> Workflow permissions)
 
+### Trigger konflux build
+This Github action opens a pr with a timestamp file, with the aim of easily triggering a build on Konflux. (May need to add the file to cel expressions in the tekton pipelines)
+
+### Usage
+```
+name: Trigger Konflux build
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-konflux-build:
+    uses: securesign/actions/.github/workflows/trigger-konflux-build.yaml@main
+    with:
+      branch: main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+In order for the action to work correctly there are two settings that need to be changed for the repo.
+
+1. Actions need to be able to create pull requests (settings -> Actions -> General -> Workflow permissions)
+2. Actions need read and write permissions (settings -> Actions -> General -> Workflow permissions)
+
 # Contributing
 If you want to add a reusable GitHub action, please refer to the documentation [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows).


### PR DESCRIPTION
If you have ever spent anytime in the konflux pipelines, you'll know that more often then not, a build will be fine on pull-request, but then when you push it may fail due to a HTTP error, or a task pull error, or something else, to trigger a build you then need to  go and make small changes, open a pr push and hope it doesn't fail again, this action automates this process using a timestamp file, it will create the pr for you and save you time. 