### PR TITLE
Fix: generate GitHub App token inside reusable workflow

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -16,9 +16,14 @@ on:
         required: true
         type: string
         description: 'Downstream branch to merge into (e.g., main)'
-    secrets:
-      token:
+      app_id:
         required: true
+        type: string
+        description: 'GitHub App ID for token generation'
+    secrets:
+      app_private_key:
+        required: true
+        description: 'GitHub App private key for token generation'
 
 permissions:
   contents: write
@@ -28,6 +33,13 @@ jobs:
   sync-upstream:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
       - name: Derive upstream owner/repo
         id: upstream-info
         run: |
@@ -56,7 +68,7 @@ jobs:
           echo "ref=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "Detected latest upstream release: $LATEST_TAG"
         env:
-          GH_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER_REPO: ${{ steps.upstream-info.outputs.owner_repo }}
 
       - name: Set upstream ref
@@ -77,7 +89,7 @@ jobs:
         with:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 0
-          token: ${{ secrets.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check if already up-to-date
         id: check-uptodate
@@ -109,7 +121,7 @@ jobs:
           git checkout -b "$SYNC_BRANCH" FETCH_HEAD
           git push -f origin "$SYNC_BRANCH"
         env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
 
@@ -153,7 +165,7 @@ jobs:
           EXISTING_PR=$(gh pr list --state open --head "$SYNC_BRANCH" --json number --jq '.[0].number // empty')
           echo "pr_number=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SYNC_BRANCH: ${{ steps.push.outputs.sync_branch }}
 
       - name: Create or update PR
@@ -176,7 +188,7 @@ jobs:
               --label "kind/sync-fork-to-upstream"
           fi
         env:
-          GH_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           SYNC_BRANCH: ${{ steps.push.outputs.sync_branch }}

--- a/README.md
+++ b/README.md
@@ -70,26 +70,15 @@ on:
         default: ''
 
 jobs:
-  generate-token:
-    runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.app-token.outputs.token }}
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-
   sync:
-    needs: generate-token
     uses: securesign/actions/.github/workflows/sync-upstream.yaml@main
     with:
       upstream_repo: https://github.com/sigstore/rekor
       upstream_ref: ${{ inputs.upstream_ref || '' }}
       target_branch: main
+      app_id: ${{ vars.SYNC_APP_ID }}
     secrets:
-      token: ${{ needs.generate-token.outputs.token }}
+      app_private_key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 ```
 
 #### Inputs
@@ -98,11 +87,12 @@ jobs:
 | `upstream_repo` | string | yes | Upstream repository URL (e.g., `https://github.com/sigstore/rekor`) |
 | `upstream_ref` | string | no | Specific upstream ref (tag/branch) to merge. Auto-detects latest release if empty. |
 | `target_branch` | string | yes | Downstream branch to merge into (e.g., `main`) |
+| `app_id` | string | yes | GitHub App ID for token generation |
 
 #### Secrets
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `token` | yes | GitHub token with contents write + pull-requests write. Use a GitHub App token (via `actions/create-github-app-token`) so PRs automatically trigger CI workflows. |
+| `app_private_key` | yes | GitHub App private key for token generation |
 
 #### GitHub App Setup
 1. Create a GitHub App in the securesign org with permissions: **Contents: Read & Write**, **Pull Requests: Read & Write**


### PR DESCRIPTION
## Summary
- Moves GitHub App token generation into the reusable workflow itself
- Callers now pass `app_id` (input) and `app_private_key` (secret) instead of a pre-generated token
- Fixes the empty token bug: job outputs masked as secrets cannot be passed to reusable workflows via `secrets:`

## Root cause
`actions/create-github-app-token` registers its output token as a secret (masked). GitHub prevents masked values from being passed through job outputs to reusable workflow secrets, so the token arrived empty.

## Test plan
- [ ] Merge this PR first
- [ ] Merge the corresponding securesign/rekor PR
- [ ] Trigger sync-upstream manually on rekor to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)