### PR TITLE
Fix SIGPIPE in sync-upstream PR body generation

### DIFF
--- a/sync-upstream/action.yaml
+++ b/sync-upstream/action.yaml
@@ -116,7 +116,7 @@ runs:
       if: steps.check-uptodate.outputs.uptodate == 'false'
       id: pr-body
       run: |
-        COMMIT_LOG=$(git log --oneline "origin/${TARGET_BRANCH}..FETCH_HEAD" | head -50)
+        COMMIT_LOG=$(git log --oneline -50 "origin/${TARGET_BRANCH}..FETCH_HEAD")
         COMMIT_COUNT=$(git rev-list --count "origin/${TARGET_BRANCH}..FETCH_HEAD")
 
         DELIMITER=$(openssl rand -hex 16)


### PR DESCRIPTION
## Summary
One-line fix: use `git log -50` instead of `git log | head -50`.

## Root cause
The composite action shell runs with `pipefail`. When `head -50` closes the pipe after 50 lines, `git log` (which has 114 commits to output) receives SIGPIPE and exits 141. With `pipefail`, that becomes the step's exit code.

## Fix
`git log --oneline -50` limits output at the source — no pipe, no SIGPIPE.

## Tested
- Cloned securesign/rekor, fetched upstream v1.5.2 (114 commits difference)
- Ran the full "Generate PR body" step under `bash -e -o pipefail` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)