### PR TITLE
Fix gh CLI targeting parent repo instead of fork

### DIFF
--- a/sync-upstream/action.yaml
+++ b/sync-upstream/action.yaml
@@ -150,11 +150,12 @@ runs:
       if: steps.check-uptodate.outputs.uptodate == 'false'
       id: existing-pr
       run: |
-        EXISTING_PR=$(gh pr list --state open --head "$SYNC_BRANCH" --json number --jq '.[0].number // empty')
+        EXISTING_PR=$(gh pr list --repo "$GH_REPO" --state open --head "$SYNC_BRANCH" --json number --jq '.[0].number // empty')
         echo "pr_number=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
         SYNC_BRANCH: ${{ steps.push.outputs.sync_branch }}
 
     - name: Create or update PR
@@ -164,12 +165,12 @@ runs:
 
         if [ -n "$EXISTING_PR" ]; then
           echo "Updating existing PR #${EXISTING_PR}"
-          gh pr edit "$EXISTING_PR" \
+          gh pr edit "$EXISTING_PR" --repo "$GH_REPO" \
             --title "$PR_TITLE" \
             --body "$PR_BODY"
         else
           echo "Creating new PR"
-          gh pr create \
+          gh pr create --repo "$GH_REPO" \
             --base "$TARGET_BRANCH" \
             --head "$SYNC_BRANCH" \
             --title "$PR_TITLE" \
@@ -179,6 +180,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
         UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
         TARGET_BRANCH: ${{ inputs.target_branch }}
         SYNC_BRANCH: ${{ steps.push.outputs.sync_branch }}


### PR DESCRIPTION
## Summary
Add explicit `--repo` flag to all `gh pr` commands using `${{ github.repository }}`.

## Root cause
`securesign/rekor` is a fork of `sigstore/rekor`. The `gh` CLI defaults to the parent repo in forks, so `gh pr create --label "kind/sync-fork-to-upstream"` was looking for the label in `sigstore/rekor` where it doesn't exist.

## Test plan
- [x] Verified `kind/sync-fork-to-upstream` exists in `securesign/rekor` but NOT in `sigstore/rekor`
- [x] YAML validated with `yq`
- [ ] Merge and re-trigger sync-upstream on rekor

🤖 Generated with [Claude Code](https://claude.com/claude-code)