### PR TITLE
Add auto-resolve merge conflicts to sync-upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,21 @@ In order for the action to work correctly there are two settings that need to be
 2. Actions need read and write permissions (settings -> Actions -> General -> Workflow permissions)
 
 ### Sync Upstream
-Automates syncing downstream forks with upstream repository releases. Detects the latest upstream release tag (or accepts an explicit ref), pushes it as a branch, and creates a PR for review. Merge conflicts are visible in the GitHub PR UI and must be resolved before merging.
+Automates syncing downstream forks with upstream repository releases. Detects the latest upstream release tag (or accepts an explicit ref), merges the downstream branch into it, auto-resolves known conflict patterns, and creates a PR for review.
+
+#### Auto-resolved conflict patterns
+| Pattern | Resolution |
+|---------|-----------|
+| Dockerfile `FROM` version conflicts | Picks the side with the newer image version |
+| Dockerfile digest-only conflicts | Takes upstream when images differ only in `@sha256:` digest |
+| `go.mod` dependency version conflicts | Three-way merge: picks newest semver per dependency, clamps `go` directive to ubi9/go-toolset ceiling |
+| GitHub Actions version bumps (`uses: action@SHA # vX.Y.Z`) | Picks the side with the newer version |
+| Downstream-only files (`.tekton/`, custom workflows, etc.) | Auto-detected and restored from the target branch |
+| `go.sum` conflicts | Removed and regenerated via `go mod tidy` |
+| User-configured upstream patterns | Takes upstream content for files matching `take_upstream_patterns` |
+| User-configured downstream patterns | Takes downstream content for files matching `take_downstream_patterns` |
+
+Unknown conflict types (e.g., source code changes) will cause the action to fail without pushing, requiring manual resolution.
 
 #### Usage
 
@@ -72,14 +86,11 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.SYNC_APP_ID }}
+          client-id: ${{ vars.SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 
       - uses: securesign/actions/sync-upstream@main
@@ -90,18 +101,39 @@ jobs:
           target_branch: main
 ```
 
+For repos with generated protobuf files or downstream-specific test fixtures, use `take_upstream_patterns` and `take_downstream_patterns` to auto-resolve additional conflict types:
+
+```yaml
+      - uses: securesign/actions/sync-upstream@main
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          upstream_repo: https://github.com/sigstore/fulcio
+          target_branch: main
+          take_upstream_patterns: |
+            \.pb\.go$
+            _grpc\.pb\.go$
+          take_downstream_patterns: |
+            testdata/
+```
+
 #### Inputs
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | GitHub token with contents write + pull-requests write. Use a GitHub App token so PRs trigger CI. |
-| `upstream_repo` | string | yes | Upstream repository URL (e.g., `https://github.com/sigstore/rekor`) |
-| `upstream_ref` | string | no | Specific upstream ref (tag/branch) to merge. Auto-detects latest release if empty. |
-| `target_branch` | string | yes | Downstream branch to merge into (e.g., `main`) |
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `token` | string | yes | | GitHub token with contents write + pull-requests write. Use a GitHub App token so PRs trigger CI. |
+| `upstream_repo` | string | yes | | Upstream repository URL (e.g., `https://github.com/sigstore/rekor`) |
+| `upstream_ref` | string | no | (latest release) | Specific upstream ref (tag/branch) to merge. Auto-detects latest release if empty. |
+| `target_branch` | string | yes | | Downstream branch to merge into (e.g., `main`) |
+| `resolve_conflicts` | string | no | `true` | Auto-resolve known merge conflict patterns. Set to `false` to push the unresolved branch. |
+| `go_version_ceiling_image` | string | no | `registry.redhat.io/ubi9/go-toolset:latest` | Container image used to determine the max allowed Go version via the Red Hat Pyxis API. |
+| `go_version_ceiling` | string | no | | Explicit Go version ceiling (e.g., `1.26.2`). Skips Pyxis API lookup when set. |
+| `downstream_only_files` | string | no | | Newline-separated list of additional files to always restore from the target branch. |
+| `take_upstream_patterns` | string | no | `(^|/)CHANGELOG` | Newline-separated grep -E patterns for files to auto-resolve with upstream content. Default includes CHANGELOG files. |
+| `take_downstream_patterns` | string | no | | Newline-separated grep -E patterns for files to auto-resolve with downstream content (e.g., `testdata/`). |
 
 #### GitHub App Setup
 1. Create a GitHub App in the securesign org with permissions: **Contents: Read & Write**, **Pull Requests: Read & Write**
 2. Install the app on the repositories that need upstream sync
-3. Store the App ID as an org-level variable: `SYNC_APP_ID`
+3. Store the App Client ID as an org-level variable: `SYNC_APP_CLIENT_ID`
 4. Store the private key as an org-level secret: `SYNC_APP_PRIVATE_KEY`
 
 #### Security
@@ -109,9 +141,34 @@ The caller workflow generates a short-lived GitHub App installation token (1hr e
 
 #### Features
 - **Auto-detection**: Queries the upstream repo's latest GitHub Release when no `upstream_ref` is provided
+- **Auto-conflict-resolution**: Resolves Dockerfile, go.mod, workflow, and downstream-only file conflicts automatically
+- **Safe push**: Only pushes after all conflicts are resolved and committed. Failures push the sync branch for local continuation.
 - **Idempotent**: Updates existing sync PRs instead of creating duplicates
-- **Conflict-safe**: Merge conflicts are shown in the GitHub PR UI for manual resolution
 - **Skip logic**: Skips if the target branch already contains the upstream ref
+- **Resolution guide**: When conflicts remain, the job summary includes categorized files and step-by-step local resolution instructions
+
+#### Manual Resolution
+
+When the action cannot auto-resolve all conflicts, it pushes the sync branch (with the upstream commit) and writes a resolution guide to the GitHub Actions job summary. To continue locally:
+
+```bash
+# 1. Check out the sync branch and start the merge
+git fetch origin
+git checkout sync-upstream/main/<tag>
+git merge origin/main
+
+# 2. Auto-resolve known patterns (Dockerfiles, go.mod, workflow version bumps)
+go install github.com/securesign/actions/sync-upstream/resolve-conflicts@main
+resolve-conflicts all
+
+# 3. Resolve remaining conflicts manually, then commit and push
+git diff --name-only --diff-filter=U   # list what's left
+# ... fix remaining files ...
+git add -A && git commit
+git push origin sync-upstream/main/<tag>
+```
+
+The `resolve-conflicts all` command auto-detects all conflicting files, resolves Dockerfiles, go.mod (three-way merge), and workflow version bumps, then reports what's left for manual attention.
 
 #### Repository Settings
 1. Actions need to be able to create pull requests (Settings -> Actions -> General -> Workflow permissions)

--- a/sync-upstream/action.yaml
+++ b/sync-upstream/action.yaml
@@ -18,6 +18,36 @@ inputs:
   target_branch:
     description: 'Downstream branch to merge into (e.g., main)'
     required: true
+  resolve_conflicts:
+    description: 'Auto-resolve known merge conflict patterns (true/false)'
+    required: false
+    default: 'true'
+  go_version_ceiling_image:
+    description: 'Container image that determines max Go version (e.g., registry.redhat.io/ubi9/go-toolset:latest)'
+    required: false
+    default: 'registry.redhat.io/ubi9/go-toolset:latest'
+  go_version_ceiling:
+    description: 'Explicit Go version ceiling override (e.g., 1.26.2). If set, skips Pyxis API lookup.'
+    required: false
+    default: ''
+  downstream_only_files:
+    description: 'Newline-separated list of files to always restore from target branch after merge'
+    required: false
+    default: ''
+  take_upstream_patterns:
+    description: >
+      Newline-separated list of grep -E patterns for conflicting files that should be
+      auto-resolved by taking upstream (HEAD) content.
+      Default includes CHANGELOG files. Add patterns like '\.pb\.go$' for generated protobuf.
+    required: false
+    default: '(^|/)CHANGELOG'
+  take_downstream_patterns:
+    description: >
+      Newline-separated list of grep -E patterns for conflicting files that should be
+      auto-resolved by taking downstream (target branch) content.
+      Example: 'testdata/' to keep downstream test fixtures.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -70,7 +100,7 @@ runs:
         DETECTED_REF: ${{ steps.detect-release.outputs.ref }}
 
     - name: Checkout downstream repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.target_branch }}
         fetch-depth: 0
@@ -95,7 +125,7 @@ runs:
         OWNER_REPO: ${{ steps.upstream-info.outputs.owner_repo }}
         UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
 
-    - name: Push upstream ref as sync branch
+    - name: Create sync branch locally
       if: steps.check-uptodate.outputs.uptodate == 'false'
       id: push
       run: |
@@ -104,13 +134,37 @@ runs:
 
         echo "sync_branch=$SYNC_BRANCH" >> "$GITHUB_OUTPUT"
 
-        git checkout -b "$SYNC_BRANCH" FETCH_HEAD
-        git push -f origin "$SYNC_BRANCH"
+        # Dereference tag to commit and create local branch (no push yet)
+        UPSTREAM_COMMIT=$(git rev-parse FETCH_HEAD^{commit})
+        git checkout -B "$SYNC_BRANCH" "$UPSTREAM_COMMIT"
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
         UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
         TARGET_BRANCH: ${{ inputs.target_branch }}
+
+    - name: Setup Go
+      if: steps.check-uptodate.outputs.uptodate == 'false' && inputs.resolve_conflicts == 'true'
+      uses: actions/setup-go@v6
+      with:
+        go-version: 'stable'
+        cache: false
+
+    - name: Merge, resolve conflicts, and push
+      id: merge
+      if: steps.check-uptodate.outputs.uptodate == 'false'
+      run: bash "${GITHUB_ACTION_PATH}/resolve-conflicts.sh"
+      shell: bash
+      env:
+        SYNC_BRANCH: ${{ steps.push.outputs.sync_branch }}
+        TARGET_BRANCH: ${{ inputs.target_branch }}
+        RESOLVE_CONFLICTS: ${{ inputs.resolve_conflicts }}
+        GO_CEILING_IMAGE: ${{ inputs.go_version_ceiling_image }}
+        GO_CEILING_OVERRIDE: ${{ inputs.go_version_ceiling }}
+        DOWNSTREAM_ONLY_FILES: ${{ inputs.downstream_only_files }}
+        TAKE_UPSTREAM_PATTERNS: ${{ inputs.take_upstream_patterns }}
+        TAKE_DOWNSTREAM_PATTERNS: ${{ inputs.take_downstream_patterns }}
+        UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
+        GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Generate PR body
       if: steps.check-uptodate.outputs.uptodate == 'false'
@@ -188,17 +242,52 @@ runs:
         PR_BODY: ${{ steps.pr-body.outputs.body }}
 
     - name: Summary
-      if: always()
+      if: always() && steps.check-uptodate.outcome == 'success'
       run: |
         if [ "$UPTODATE" = "true" ]; then
           echo "### :white_check_mark: Already up-to-date" >> "$GITHUB_STEP_SUMMARY"
           echo "Branch \`${TARGET_BRANCH}\` already contains upstream \`${UPSTREAM_REF}\`." >> "$GITHUB_STEP_SUMMARY"
-        else
+        elif [ "$MERGE_OUTCOME" = "success" ]; then
           echo "### :white_check_mark: Sync PR created" >> "$GITHUB_STEP_SUMMARY"
           echo "Upstream \`${UPSTREAM_REF}\` → \`${TARGET_BRANCH}\`." >> "$GITHUB_STEP_SUMMARY"
+        elif [ "$MERGE_OUTCOME" = "failure" ] && [ -f /tmp/unresolved-conflicts.txt ]; then
+          SYNC_BRANCH="${SYNC_BRANCH}"
+          echo "### :warning: Upstream sync needs manual resolution" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Merged \`${UPSTREAM_REF}\` into \`${TARGET_BRANCH}\` — some conflicts could not be auto-resolved." >> "$GITHUB_STEP_SUMMARY"
+          echo "The sync branch \`${SYNC_BRANCH}\` has been pushed so you can continue locally." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### Unresolved files" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "- \`${f}\`" >> "$GITHUB_STEP_SUMMARY"
+          done < /tmp/unresolved-conflicts.txt
+          cat >> "$GITHUB_STEP_SUMMARY" <<GUIDE
+
+#### Resolve locally
+
+\`\`\`bash
+# 1. Check out the sync branch and start the merge
+git fetch origin
+git checkout ${SYNC_BRANCH}
+git merge origin/${TARGET_BRANCH}
+
+# 2. Auto-resolve known patterns (Dockerfiles, go.mod, workflow version bumps)
+go install github.com/securesign/actions/sync-upstream/resolve-conflicts@main
+resolve-conflicts all
+
+# 3. Resolve remaining conflicts manually, then commit and push
+git diff --name-only --diff-filter=U
+git add -A && git commit
+git push origin ${SYNC_BRANCH}
+\`\`\`
+GUIDE
         fi
       shell: bash
       env:
         UPSTREAM_REF: ${{ steps.upstream-ref.outputs.ref }}
         TARGET_BRANCH: ${{ inputs.target_branch }}
+        SYNC_BRANCH: ${{ steps.push.outputs.sync_branch }}
         UPTODATE: ${{ steps.check-uptodate.outputs.uptodate }}
+        MERGE_OUTCOME: ${{ steps.merge.outcome }}

--- a/sync-upstream/resolve-conflicts.sh
+++ b/sync-upstream/resolve-conflicts.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYNC_BRANCH="${SYNC_BRANCH:?SYNC_BRANCH is required}"
+TARGET_BRANCH="${TARGET_BRANCH:?TARGET_BRANCH is required}"
+RESOLVE_CONFLICTS="${RESOLVE_CONFLICTS:-true}"
+GO_CEILING_IMAGE="${GO_CEILING_IMAGE:-registry.redhat.io/ubi9/go-toolset:latest}"
+GO_CEILING_OVERRIDE="${GO_CEILING_OVERRIDE:-}"
+DOWNSTREAM_ONLY_FILES="${DOWNSTREAM_ONLY_FILES:-}"
+TAKE_UPSTREAM_PATTERNS="${TAKE_UPSTREAM_PATTERNS:-}"
+TAKE_DOWNSTREAM_PATTERNS="${TAKE_DOWNSTREAM_PATTERNS:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RESOLVE="${SCRIPT_DIR}/resolve-conflicts/resolve-conflicts"
+
+info() { echo "[resolve-conflicts] $*"; }
+err()  { echo "::error::$*"; }
+
+fatal() {
+    err "$*"
+    git merge --abort 2>/dev/null || true
+    exit 1
+}
+
+build_tool() {
+    if [[ ! -x "${RESOLVE}" ]]; then
+        echo "::group::Building resolve-conflicts tool"
+        (cd "${SCRIPT_DIR}/resolve-conflicts" && go build -o resolve-conflicts .) || fatal "Failed to build resolve-conflicts tool"
+        echo "::endgroup::"
+    fi
+}
+
+merge_target_branch() {
+    echo "::group::Merge ${TARGET_BRANCH} into ${SYNC_BRANCH}"
+    git config user.name "github-actions[bot]"
+    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    git checkout "${SYNC_BRANCH}"
+
+    local merge_exit=0
+    git merge "origin/${TARGET_BRANCH}" --no-edit || merge_exit=$?
+
+    if [[ "${merge_exit}" -eq 0 ]]; then
+        info "Merge completed without conflicts"
+        echo "::endgroup::"
+        return 1
+    fi
+
+    # Verify merge is actually in progress (not a different failure like missing identity)
+    if [[ ! -f .git/MERGE_HEAD ]]; then
+        echo "::endgroup::"
+        fatal "git merge failed (exit ${merge_exit}) but no merge in progress — check git config and permissions"
+    fi
+
+    info "Merge conflicts detected"
+    echo "::endgroup::"
+    return 0
+}
+
+get_conflicting_files() {
+    git diff --name-only --diff-filter=U
+}
+
+get_go_ceiling() {
+    if [[ -n "${GO_CEILING_OVERRIDE}" ]]; then
+        echo "${GO_CEILING_OVERRIDE}"
+        return
+    fi
+    "${RESOLVE}" go-ceiling --image "${GO_CEILING_IMAGE}" || fatal "Failed to detect Go version ceiling from ${GO_CEILING_IMAGE}"
+}
+
+restore_downstream_only_files() {
+    echo "::group::Restoring downstream-only files"
+
+    local files
+    files=$(git diff --name-only --diff-filter=A "${MERGE_BASE}" "origin/${TARGET_BRANCH}" 2>/dev/null || true)
+    if [[ -n "${DOWNSTREAM_ONLY_FILES}" ]]; then
+        files="${files}"$'\n'"${DOWNSTREAM_ONLY_FILES}"
+    fi
+
+    local count=0
+    while IFS= read -r file; do
+        [[ -z "${file}" ]] && continue
+        if git show "origin/${TARGET_BRANCH}:${file}" &>/dev/null; then
+            git checkout "origin/${TARGET_BRANCH}" -- "${file}" && {
+                git add "${file}"
+                info "Restored: ${file}"
+                count=$((count + 1))
+            }
+        fi
+    done <<< "${files}"
+    info "Restored ${count} downstream-only files"
+    echo "::endgroup::"
+}
+
+resolve_image_versions() {
+    echo "::group::Resolving image version conflicts"
+    local conflicts
+    conflicts=$(get_conflicting_files | grep -iE '(^|/)(Dockerfile|docker-compose)' || true)
+    if [[ -z "${conflicts}" ]]; then
+        info "No image version conflicts"
+        echo "::endgroup::"
+        return
+    fi
+
+    while IFS= read -r f; do
+        [[ -z "${f}" ]] && continue
+        "${RESOLVE}" dockerfile --file "${f}" || fatal "Failed to resolve ${f}"
+        git add "${f}"
+        info "Resolved: ${f}"
+    done <<< "${conflicts}"
+    echo "::endgroup::"
+}
+
+resolve_gomod() {
+    local go_ceiling="$1"
+    echo "::group::Resolving go.mod conflicts"
+    local conflicts
+    conflicts=$(get_conflicting_files | grep '/\?go\.mod$' || true)
+    if [[ -z "${conflicts}" ]]; then
+        info "No go.mod conflicts"
+        echo "::endgroup::"
+        return
+    fi
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    # Collect directories containing resolved go.mod files for later tidy
+    local gomod_dirs=()
+
+    while IFS= read -r f; do
+        [[ -z "${f}" ]] && continue
+        git show "${MERGE_BASE}:${f}" > "${tmpdir}/base.mod" 2>/dev/null || echo "module unknown" > "${tmpdir}/base.mod"
+        git show "MERGE_HEAD:${f}" > "${tmpdir}/ours.mod" 2>/dev/null || fatal "Cannot auto-resolve ${f}: modify/delete conflict (file missing on one side) — resolve manually"
+        git show "HEAD:${f}" > "${tmpdir}/theirs.mod" 2>/dev/null || fatal "Cannot auto-resolve ${f}: modify/delete conflict (file missing on one side) — resolve manually"
+        "${RESOLVE}" gomod --base "${tmpdir}/base.mod" --ours "${tmpdir}/ours.mod" --theirs "${tmpdir}/theirs.mod" \
+            --go-ceiling "${go_ceiling}" --output "${f}" || fatal "Failed to merge ${f}"
+        git add "${f}"
+        gomod_dirs+=("$(dirname "${f}")")
+        info "Resolved: ${f} (ceiling: ${go_ceiling})"
+    done <<< "${conflicts}"
+    rm -rf "${tmpdir}"
+    echo "::endgroup::"
+
+    echo "::group::Running go mod tidy"
+    for dir in "${gomod_dirs[@]}"; do
+        local sum="${dir}/go.sum"
+        [[ "${dir}" == "." ]] && sum="go.sum"
+        if [[ -f "${sum}" ]] && grep -q '^<<<<<<< ' "${sum}" 2>/dev/null; then
+            rm "${sum}"
+            info "Removed conflicted ${sum} (will be regenerated)"
+        fi
+
+        info "Running go mod tidy in ${dir}"
+        (cd "${dir}" && go mod tidy) || fatal "go mod tidy failed in ${dir}"
+        git add "${dir}/go.mod" "${dir}/go.sum"
+    done
+    echo "::endgroup::"
+}
+
+resolve_workflows() {
+    echo "::group::Resolving workflow conflicts"
+    local conflicts
+    conflicts=$(get_conflicting_files | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
+    if [[ -z "${conflicts}" ]]; then
+        info "No workflow conflicts"
+        echo "::endgroup::"
+        return
+    fi
+
+    while IFS= read -r f; do
+        [[ -z "${f}" ]] && continue
+        "${RESOLVE}" workflow --file "${f}" || fatal "Failed to resolve ${f}"
+        git add "${f}"
+        info "Resolved: ${f}"
+    done <<< "${conflicts}"
+    echo "::endgroup::"
+}
+
+resolve_take_upstream() {
+    [[ -z "${TAKE_UPSTREAM_PATTERNS}" ]] && return
+    echo "::group::Resolving conflicts (take upstream)"
+    local remaining
+    remaining=$(get_conflicting_files)
+    [[ -z "${remaining}" ]] && { echo "::endgroup::"; return; }
+
+    while IFS= read -r pattern; do
+        [[ -z "${pattern}" ]] && continue
+        local matches
+        matches=$(echo "${remaining}" | grep -E "${pattern}" || true)
+        [[ -z "${matches}" ]] && continue
+        while IFS= read -r f; do
+            [[ -z "${f}" ]] && continue
+            git checkout --ours "${f}" || fatal "Failed to resolve ${f}"
+            git add "${f}"
+            info "Resolved (upstream pattern '${pattern}'): ${f}"
+        done <<< "${matches}"
+        remaining=$(get_conflicting_files)
+    done <<< "${TAKE_UPSTREAM_PATTERNS}"
+    echo "::endgroup::"
+}
+
+resolve_take_downstream() {
+    [[ -z "${TAKE_DOWNSTREAM_PATTERNS}" ]] && return
+    echo "::group::Resolving conflicts (take downstream)"
+    local remaining
+    remaining=$(get_conflicting_files)
+    [[ -z "${remaining}" ]] && { echo "::endgroup::"; return; }
+
+    while IFS= read -r pattern; do
+        [[ -z "${pattern}" ]] && continue
+        local matches
+        matches=$(echo "${remaining}" | grep -E "${pattern}" || true)
+        [[ -z "${matches}" ]] && continue
+        while IFS= read -r f; do
+            [[ -z "${f}" ]] && continue
+            git checkout --theirs "${f}" || fatal "Failed to resolve ${f}"
+            git add "${f}"
+            info "Resolved (downstream pattern '${pattern}'): ${f}"
+        done <<< "${matches}"
+        remaining=$(get_conflicting_files)
+    done <<< "${TAKE_DOWNSTREAM_PATTERNS}"
+    echo "::endgroup::"
+}
+
+main() {
+    info "Starting: ${SYNC_BRANCH} <- ${TARGET_BRANCH}"
+
+    if [[ "${RESOLVE_CONFLICTS}" == "true" ]]; then
+        build_tool
+    fi
+
+    if ! merge_target_branch; then
+        info "No conflicts to resolve"
+    elif [[ "${RESOLVE_CONFLICTS}" != "true" ]]; then
+        info "Conflict resolution disabled, pushing unresolved branch"
+    else
+        MERGE_BASE=$(git merge-base HEAD "origin/${TARGET_BRANCH}") || fatal "Failed to compute merge-base"
+        info "Merge base: ${MERGE_BASE}"
+
+        restore_downstream_only_files
+
+        local go_ceiling
+        go_ceiling=$(get_go_ceiling)
+        info "Go version ceiling: ${go_ceiling}"
+
+        resolve_image_versions
+        resolve_gomod "${go_ceiling}"
+        resolve_workflows
+        resolve_take_upstream
+        resolve_take_downstream
+
+        echo "::group::Checking for remaining conflicts"
+        local remaining
+        remaining=$(get_conflicting_files)
+        if [[ -n "${remaining}" ]]; then
+            local remaining_count
+            remaining_count=$(echo "${remaining}" | grep -c .)
+            err "Unresolved conflicts remain (${remaining_count} files):"
+            echo "${remaining}" | while IFS= read -r f; do err "  - ${f}"; done
+            echo "::endgroup::"
+
+            echo "${remaining}" > /tmp/unresolved-conflicts.txt
+
+            info "Pushing sync branch (upstream commit only) for local continuation"
+            git merge --abort 2>/dev/null || true
+            git push -f origin "${SYNC_BRANCH}" 2>/dev/null || true
+
+            err "Cannot proceed with unresolved conflicts — see job summary for resolution guide"
+            exit 1
+        fi
+        info "All conflicts resolved"
+        echo "::endgroup::"
+
+        if [[ ! -f .git/MERGE_HEAD ]]; then
+            fatal "Merge state lost during resolution — .git/MERGE_HEAD missing"
+        fi
+
+        echo "::group::Committing"
+        git add -A
+        git commit --no-edit || fatal "git commit failed"
+        echo "::endgroup::"
+    fi
+
+    echo "::group::Pushing"
+    git push -f origin "${SYNC_BRANCH}" || fatal "git push failed"
+    echo "::endgroup::"
+    info "Done"
+}
+
+main "$@"

--- a/sync-upstream/resolve-conflicts/.gitignore
+++ b/sync-upstream/resolve-conflicts/.gitignore
@@ -1,0 +1,1 @@
+resolve-conflicts

--- a/sync-upstream/resolve-conflicts/cmd/dockerfile.go
+++ b/sync-upstream/resolve-conflicts/cmd/dockerfile.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/dockerfile"
+)
+
+func Dockerfile(args []string) {
+	fs := flag.NewFlagSet("dockerfile", flag.ExitOnError)
+	file := fs.String("file", "", "path to Dockerfile with conflict markers (omit to auto-detect from git)")
+	fs.Parse(args)
+
+	if *file != "" {
+		if err := dockerfile.Resolve(*file); err != nil {
+			fmt.Fprintf(os.Stderr, "resolving: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	resolved, failed, err := dockerfile.ResolveAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dockerfile: %v\n", err)
+		os.Exit(1)
+	}
+	printResult("dockerfile", resolved, failed)
+}

--- a/sync-upstream/resolve-conflicts/cmd/goceiling.go
+++ b/sync-upstream/resolve-conflicts/cmd/goceiling.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/pyxis"
+)
+
+func GoCeiling(args []string) {
+	fs := flag.NewFlagSet("go-ceiling", flag.ExitOnError)
+	image := fs.String("image", "registry.redhat.io/ubi9/go-toolset:latest", "container image to check for Go version")
+	fs.Parse(args)
+
+	version, err := pyxis.GetGoVersion(*image)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(version)
+}

--- a/sync-upstream/resolve-conflicts/cmd/gomod.go
+++ b/sync-upstream/resolve-conflicts/cmd/gomod.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gomod"
+)
+
+func Gomod(args []string) {
+	fs := flag.NewFlagSet("gomod", flag.ExitOnError)
+	baseFile := fs.String("base", "", "path to base (merge-base) go.mod")
+	oursFile := fs.String("ours", "", "path to ours (downstream) go.mod")
+	theirsFile := fs.String("theirs", "", "path to theirs (upstream) go.mod")
+	goCeiling := fs.String("go-ceiling", "", "maximum allowed Go version")
+	outputFile := fs.String("output", "", "path to write merged go.mod")
+	fs.Parse(args)
+
+	// Explicit three-way merge mode
+	if *baseFile != "" || *oursFile != "" || *theirsFile != "" || *outputFile != "" {
+		if *baseFile == "" || *oursFile == "" || *theirsFile == "" || *outputFile == "" {
+			fmt.Fprintln(os.Stderr, "usage: resolve-conflicts gomod --base FILE --ours FILE --theirs FILE --output FILE [--go-ceiling VERSION]")
+			os.Exit(1)
+		}
+
+		base, err := gomod.ParseFile(*baseFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "parsing base: %v\n", err)
+			os.Exit(1)
+		}
+		ours, err := gomod.ParseFile(*oursFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "parsing ours: %v\n", err)
+			os.Exit(1)
+		}
+		theirs, err := gomod.ParseFile(*theirsFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "parsing theirs: %v\n", err)
+			os.Exit(1)
+		}
+
+		merged, err := gomod.Merge(base, ours, theirs, *goCeiling)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "merging: %v\n", err)
+			os.Exit(1)
+		}
+
+		merged.Cleanup()
+		out, err := merged.Format()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "formatting: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := os.WriteFile(*outputFile, out, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "writing: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Auto-detect mode
+	resolved, failed, err := gomod.ResolveAll(*goCeiling)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gomod: %v\n", err)
+		os.Exit(1)
+	}
+	printResult("gomod", resolved, failed)
+}

--- a/sync-upstream/resolve-conflicts/cmd/run.go
+++ b/sync-upstream/resolve-conflicts/cmd/run.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/dockerfile"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gomod"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/workflow"
+)
+
+func Run(args []string) {
+	fs := flag.NewFlagSet("all", flag.ExitOnError)
+	goCeiling := fs.String("go-ceiling", "", "maximum allowed Go version (optional)")
+	fs.Parse(args)
+
+	var allResolved, allFailed []string
+
+	r, f, err := dockerfile.ResolveAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dockerfile: %v\n", err)
+		os.Exit(1)
+	}
+	allResolved = append(allResolved, r...)
+	allFailed = append(allFailed, f...)
+
+	r, f, err = gomod.ResolveAll(*goCeiling)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gomod: %v\n", err)
+		os.Exit(1)
+	}
+	allResolved = append(allResolved, r...)
+	allFailed = append(allFailed, f...)
+
+	r, f, err = workflow.ResolveAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workflow: %v\n", err)
+		os.Exit(1)
+	}
+	allResolved = append(allResolved, r...)
+	allFailed = append(allFailed, f...)
+
+	printResult("all", allResolved, allFailed)
+}
+
+func printResult(name string, resolved, failed []string) {
+	fmt.Printf("\n[%s] Resolved: %d, Failed: %d\n", name, len(resolved), len(failed))
+	if len(failed) > 0 {
+		fmt.Println("Failed (resolve manually):")
+		for _, f := range failed {
+			fmt.Printf("  %s\n", f)
+		}
+	}
+}

--- a/sync-upstream/resolve-conflicts/cmd/workflow.go
+++ b/sync-upstream/resolve-conflicts/cmd/workflow.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/workflow"
+)
+
+func Workflow(args []string) {
+	fs := flag.NewFlagSet("workflow", flag.ExitOnError)
+	file := fs.String("file", "", "path to workflow file with conflict markers (omit to auto-detect from git)")
+	fs.Parse(args)
+
+	if *file != "" {
+		if err := workflow.Resolve(*file); err != nil {
+			fmt.Fprintf(os.Stderr, "resolving: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	resolved, failed, err := workflow.ResolveAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workflow: %v\n", err)
+		os.Exit(1)
+	}
+	printResult("workflow", resolved, failed)
+}

--- a/sync-upstream/resolve-conflicts/go.mod
+++ b/sync-upstream/resolve-conflicts/go.mod
@@ -1,0 +1,5 @@
+module github.com/securesign/actions/sync-upstream/resolve-conflicts
+
+go 1.26.3
+
+require golang.org/x/mod v0.36.0

--- a/sync-upstream/resolve-conflicts/go.sum
+++ b/sync-upstream/resolve-conflicts/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=

--- a/sync-upstream/resolve-conflicts/main.go
+++ b/sync-upstream/resolve-conflicts/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/cmd"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+
+	switch os.Args[1] {
+	case "all":
+		cmd.Run(os.Args[2:])
+	case "gomod":
+		cmd.Gomod(os.Args[2:])
+	case "dockerfile":
+		cmd.Dockerfile(os.Args[2:])
+	case "workflow":
+		cmd.Workflow(os.Args[2:])
+	case "go-ceiling":
+		cmd.GoCeiling(os.Args[2:])
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `resolve-conflicts - upstream sync conflict resolver
+
+Usage: resolve-conflicts <command> [flags]
+
+Commands:
+  all         Auto-resolve all known conflict patterns in the current merge
+  gomod       Three-way merge of go.mod files
+  dockerfile  Resolve Dockerfile golang version conflicts
+  workflow    Resolve GitHub Actions workflow version conflicts
+  go-ceiling  Get max Go version from Red Hat container image`)
+	os.Exit(1)
+}

--- a/sync-upstream/resolve-conflicts/pkg/conflict/parser.go
+++ b/sync-upstream/resolve-conflicts/pkg/conflict/parser.go
@@ -1,0 +1,124 @@
+package conflict
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+type Block struct {
+	Ours   string
+	Theirs string
+}
+
+type File struct {
+	Sections []Section
+}
+
+type Section struct {
+	Text     string
+	Conflict *Block
+}
+
+func Parse(r io.Reader) (*File, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), 1024*1024)
+	var f File
+	var current strings.Builder
+	var ours, theirs strings.Builder
+	inOurs, inTheirs := false, false
+	currentHasLines := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case strings.HasPrefix(line, "<<<<<<< "):
+			f.Sections = append(f.Sections, Section{Text: current.String()})
+			current.Reset()
+			currentHasLines = false
+			ours.Reset()
+			theirs.Reset()
+			inOurs = true
+			inTheirs = false
+
+		case line == "=======" && inOurs:
+			inOurs = false
+			inTheirs = true
+
+		case strings.HasPrefix(line, ">>>>>>> ") && inTheirs:
+			f.Sections = append(f.Sections, Section{
+				Conflict: &Block{Ours: ours.String(), Theirs: theirs.String()},
+			})
+			inOurs = false
+			inTheirs = false
+
+		case inOurs:
+			if ours.Len() > 0 {
+				ours.WriteByte('\n')
+			}
+			ours.WriteString(line)
+
+		case inTheirs:
+			if theirs.Len() > 0 {
+				theirs.WriteByte('\n')
+			}
+			theirs.WriteString(line)
+
+		default:
+			if currentHasLines {
+				current.WriteByte('\n')
+			}
+			current.WriteString(line)
+			currentHasLines = true
+		}
+	}
+
+	if currentHasLines {
+		f.Sections = append(f.Sections, Section{Text: current.String()})
+	}
+
+	return &f, scanner.Err()
+}
+
+func (f *File) HasConflicts() bool {
+	for _, s := range f.Sections {
+		if s.Conflict != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *File) Conflicts() []Block {
+	var blocks []Block
+	for _, s := range f.Sections {
+		if s.Conflict != nil {
+			blocks = append(blocks, *s.Conflict)
+		}
+	}
+	return blocks
+}
+
+func (f *File) Render(resolver func(Block) string) string {
+	var out strings.Builder
+	first := true
+	for _, s := range f.Sections {
+		if s.Conflict != nil {
+			resolved := resolver(*s.Conflict)
+			if out.Len() > 0 {
+				out.WriteByte('\n')
+			}
+			out.WriteString(resolved)
+			first = false
+		} else if s.Text != "" {
+			if !first {
+				out.WriteByte('\n')
+			}
+			out.WriteString(s.Text)
+			first = false
+		}
+	}
+	out.WriteByte('\n')
+	return out.String()
+}

--- a/sync-upstream/resolve-conflicts/pkg/conflict/parser_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/conflict/parser_test.go
@@ -1,0 +1,112 @@
+package conflict
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	input := `line 1
+line 2
+<<<<<<< HEAD
+      - uses: actions/setup-go@aaa111 # v6.4.0
+=======
+      - uses: actions/setup-go@bbb222 # v6.3.0
+>>>>>>> origin/main
+line 3`
+
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if len(f.Sections) != 3 {
+		t.Fatalf("got %d sections, want 3", len(f.Sections))
+	}
+
+	if f.Sections[0].Text != "line 1\nline 2" {
+		t.Errorf("section 0: %q", f.Sections[0].Text)
+	}
+
+	if f.Sections[1].Conflict == nil {
+		t.Fatal("section 1 should be a conflict")
+	}
+	if !strings.Contains(f.Sections[1].Conflict.Ours, "v6.4.0") {
+		t.Errorf("ours: %q", f.Sections[1].Conflict.Ours)
+	}
+	if !strings.Contains(f.Sections[1].Conflict.Theirs, "v6.3.0") {
+		t.Errorf("theirs: %q", f.Sections[1].Conflict.Theirs)
+	}
+
+	if f.Sections[2].Text != "line 3" {
+		t.Errorf("section 2: %q", f.Sections[2].Text)
+	}
+}
+
+func TestParseMultipleConflicts(t *testing.T) {
+	input := `before
+<<<<<<< HEAD
+ours1
+=======
+theirs1
+>>>>>>> origin/main
+middle
+<<<<<<< HEAD
+ours2
+=======
+theirs2
+>>>>>>> origin/main
+after`
+
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	conflicts := f.Conflicts()
+	if len(conflicts) != 2 {
+		t.Fatalf("got %d conflicts, want 2", len(conflicts))
+	}
+
+	if conflicts[0].Ours != "ours1" {
+		t.Errorf("conflict 0 ours: %q", conflicts[0].Ours)
+	}
+	if conflicts[1].Theirs != "theirs2" {
+		t.Errorf("conflict 1 theirs: %q", conflicts[1].Theirs)
+	}
+}
+
+func TestRender(t *testing.T) {
+	input := `before
+<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> origin/main
+after`
+
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	got := f.Render(func(b Block) string {
+		return b.Ours
+	})
+
+	want := "before\nours\nafter\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNoConflicts(t *testing.T) {
+	input := "line 1\nline 2\nline 3"
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.HasConflicts() {
+		t.Error("expected no conflicts")
+	}
+}

--- a/sync-upstream/resolve-conflicts/pkg/dockerfile/resolve.go
+++ b/sync-upstream/resolve-conflicts/pkg/dockerfile/resolve.go
@@ -1,0 +1,109 @@
+package dockerfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/conflict"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gitutil"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/semver"
+)
+
+var imageVersionRe = regexp.MustCompile(`(?:FROM|image:)\s+\S+:v?([0-9]+\.[0-9]+(?:\.[0-9]+)*)(?:[@\s\-]|$)`)
+
+func IsMatch(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	return strings.HasPrefix(base, "dockerfile") || strings.HasPrefix(base, "docker-compose")
+}
+
+func ResolveAll() (resolved, failed []string, err error) {
+	files, err := gitutil.ConflictingFiles()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, f := range files {
+		if !IsMatch(f) {
+			continue
+		}
+		if err := Resolve(f); err != nil {
+			fmt.Printf("  SKIP %s (dockerfile: %v)\n", f, err)
+			failed = append(failed, f)
+		} else {
+			fmt.Printf("  OK   %s (dockerfile)\n", f)
+			if err := gitutil.Add(f); err != nil {
+				fmt.Printf("  WARN %s: %v\n", f, err)
+			}
+			resolved = append(resolved, f)
+		}
+	}
+	return
+}
+
+func ExtractImageVersion(content string) string {
+	m := imageVersionRe.FindStringSubmatch(content)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+func Resolve(inputPath string) error {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	f, err := conflict.Parse(strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("parsing conflicts: %w", err)
+	}
+
+	if !f.HasConflicts() {
+		return nil
+	}
+
+	for _, block := range f.Conflicts() {
+		if !isImageVersionConflict(block) {
+			return fmt.Errorf("non-image-version conflict found, cannot auto-resolve")
+		}
+	}
+
+	resolved := f.Render(resolveImageConflict)
+	return os.WriteFile(inputPath, []byte(resolved), 0644)
+}
+
+func isImageVersionConflict(block conflict.Block) bool {
+	for _, side := range []string{block.Ours, block.Theirs} {
+		for _, line := range strings.Split(side, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if !isImageLine(line) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isImageLine(line string) bool {
+	return strings.HasPrefix(line, "FROM ") || strings.HasPrefix(line, "image:")
+}
+
+func resolveImageConflict(block conflict.Block) string {
+	oursVer := ExtractImageVersion(block.Ours)
+	theirsVer := ExtractImageVersion(block.Theirs)
+
+	if oursVer == "" || theirsVer == "" {
+		return block.Ours
+	}
+
+	if semver.Compare(oursVer, theirsVer) >= 0 {
+		return block.Ours
+	}
+	return block.Theirs
+}

--- a/sync-upstream/resolve-conflicts/pkg/dockerfile/resolve_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/dockerfile/resolve_test.go
@@ -1,0 +1,214 @@
+package dockerfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractImageVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"golang with sha", "FROM golang:1.26.3@sha256:abc123 AS builder", "1.26.3"},
+		{"golang no sha", "FROM golang:1.25.7 AS builder", "1.25.7"},
+		{"ubuntu", "FROM ubuntu:22.04", "22.04"},
+		{"alpine", "FROM alpine:3.19.1@sha256:def456", "3.19.1"},
+		{"scaffolding image", "FROM ghcr.io/sigstore/scaffolding/trillian_log_server:v1.7.2@sha256:abc", "1.7.2"},
+		{"no version", "FROM ubuntu", ""},
+		{"ubi base", "FROM registry.access.redhat.com/ubi9/ubi:9.4@sha256:abc", "9.4"},
+		{"alpine suffix", "FROM golang:1.22.3-alpine AS builder", "1.22.3"},
+		{"bullseye suffix", "FROM golang:1.21.0-bullseye", "1.21.0"},
+		{"bookworm suffix", "FROM node:20.11.1-bookworm-slim", "20.11.1"},
+		{"compose image", "    image: nginx:1.31.1@sha256:abc123", "1.31.1"},
+		{"compose image no sha", "    image: redis:7.2.4", "7.2.4"},
+		{"compose image with tag", "    image: postgres:16.3-alpine", "16.3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractImageVersion(tt.content)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveGolangConflict(t *testing.T) {
+	input := `# Dockerfile
+FROM ubuntu:22.04 AS base
+RUN apt-get update
+<<<<<<< HEAD
+FROM golang:1.26.3@sha256:aaa AS builder
+=======
+FROM golang:1.25.7@sha256:bbb AS builder
+>>>>>>> origin/main
+RUN go build .
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Dockerfile")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("conflict markers remain")
+	}
+	if !strings.Contains(string(got), "1.26.3") {
+		t.Error("expected newer version 1.26.3")
+	}
+	if !strings.Contains(string(got), "go build") {
+		t.Error("non-conflict content missing")
+	}
+}
+
+func TestResolveScaffoldingConflict(t *testing.T) {
+	input := `<<<<<<< HEAD
+FROM ghcr.io/sigstore/scaffolding/trillian_log_server:v1.8.0@sha256:aaa AS server
+=======
+FROM ghcr.io/sigstore/scaffolding/trillian_log_server:v1.7.2@sha256:bbb AS server
+>>>>>>> origin/main
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Dockerfile")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if !strings.Contains(string(got), "v1.8.0") {
+		t.Errorf("expected newer version v1.8.0, got: %s", string(got))
+	}
+}
+
+func TestResolveDownstreamNewer(t *testing.T) {
+	input := `<<<<<<< HEAD
+FROM golang:1.25.0@sha256:aaa AS builder
+=======
+FROM golang:1.26.3@sha256:bbb AS builder
+>>>>>>> origin/main
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Dockerfile")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if !strings.Contains(string(got), "1.26.3") {
+		t.Errorf("expected newer version 1.26.3, got: %s", string(got))
+	}
+}
+
+func TestResolveComposeImageConflict(t *testing.T) {
+	input := `services:
+  proxy:
+<<<<<<< HEAD
+    image: nginx:1.31.1@sha256:aaa
+=======
+    image: nginx:1.29.4@sha256:bbb
+>>>>>>> origin/main
+    ports:
+      - "8080:80"
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "docker-compose.yml")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("conflict markers remain")
+	}
+	if !strings.Contains(string(got), "1.31.1") {
+		t.Error("expected newer version 1.31.1")
+	}
+	if !strings.Contains(string(got), "8080:80") {
+		t.Error("non-conflict content missing")
+	}
+}
+
+func TestResolveShaOnlyConflict(t *testing.T) {
+	input := `<<<<<<< HEAD
+FROM gcr.io/distroless/static-debian12@sha256:aaa111
+=======
+FROM gcr.io/distroless/static-debian12@sha256:bbb222
+>>>>>>> origin/main
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Dockerfile")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("conflict markers remain")
+	}
+	if !strings.Contains(string(got), "sha256:aaa111") {
+		t.Error("expected ours (upstream) to be chosen for sha-only conflict")
+	}
+}
+
+func TestResolveMixedSemverShaConflict(t *testing.T) {
+	input := `<<<<<<< HEAD
+FROM golang:1.26.3@sha256:aaa AS builder
+=======
+FROM gcr.io/distroless/static@sha256:bbb
+>>>>>>> origin/main
+FROM ubuntu:22.04
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Dockerfile")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("conflict markers remain")
+	}
+	if !strings.Contains(string(got), "1.26.3") {
+		t.Error("expected ours (upstream) to be chosen when theirs has no version")
+	}
+}
+
+func TestResolveNonImageConflictFails(t *testing.T) {
+	input := `<<<<<<< HEAD
+RUN echo hello
+=======
+RUN echo world
+>>>>>>> origin/main
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Dockerfile")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err == nil {
+		t.Error("expected error for non-image conflict")
+	}
+}

--- a/sync-upstream/resolve-conflicts/pkg/gitutil/gitutil.go
+++ b/sync-upstream/resolve-conflicts/pkg/gitutil/gitutil.go
@@ -1,0 +1,45 @@
+package gitutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func ConflictingFiles() ([]string, error) {
+	out, err := exec.Command("git", "diff", "--name-only", "--diff-filter=U").Output()
+	if err != nil {
+		return nil, fmt.Errorf("listing conflicting files: %w", err)
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+func MergeBase() string {
+	out, err := exec.Command("git", "merge-base", "HEAD", "MERGE_HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func ShowToFile(ref, outPath string) error {
+	out, err := exec.Command("git", "show", ref).Output()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, out, 0644)
+}
+
+func Add(path string) error {
+	if err := exec.Command("git", "add", path).Run(); err != nil {
+		return fmt.Errorf("git add %s: %w", path, err)
+	}
+	return nil
+}

--- a/sync-upstream/resolve-conflicts/pkg/gomod/merge.go
+++ b/sync-upstream/resolve-conflicts/pkg/gomod/merge.go
@@ -1,0 +1,276 @@
+package gomod
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gitutil"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/semver"
+	"golang.org/x/mod/modfile"
+)
+
+func IsMatch(path string) bool {
+	return strings.HasSuffix(path, "go.mod")
+}
+
+func ResolveAll(goCeiling string) (resolved, failed []string, err error) {
+	files, err := gitutil.ConflictingFiles()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, f := range files {
+		if !IsMatch(f) {
+			continue
+		}
+		if err := Resolve(f, goCeiling); err != nil {
+			fmt.Printf("  SKIP %s (gomod: %v)\n", f, err)
+			failed = append(failed, f)
+			continue
+		}
+		fmt.Printf("  OK   %s (gomod)\n", f)
+		if err := gitutil.Add(f); err != nil {
+			fmt.Printf("  WARN %s: %v\n", f, err)
+		}
+		resolved = append(resolved, f)
+
+		dir := filepath.Dir(f)
+		sumFile := filepath.Join(dir, "go.sum")
+		if data, err := os.ReadFile(sumFile); err == nil && strings.Contains(string(data), "<<<<<<<") {
+			os.Remove(sumFile)
+			fmt.Printf("  Removed conflicted %s\n", sumFile)
+		}
+
+		fmt.Printf("  Running go mod tidy in %s\n", dir)
+		tidy := exec.Command("go", "mod", "tidy")
+		tidy.Dir = dir
+		tidy.Stdout = os.Stdout
+		tidy.Stderr = os.Stderr
+		if err := tidy.Run(); err != nil {
+			fmt.Printf("  WARN go mod tidy failed in %s: %v\n", dir, err)
+		}
+		gitutil.Add(filepath.Join(dir, "go.mod"))
+		gitutil.Add(filepath.Join(dir, "go.sum"))
+	}
+	return
+}
+
+func Resolve(path, goCeiling string) error {
+	mergeBase := gitutil.MergeBase()
+
+	tmpdir, err := os.MkdirTemp("", "gomod-resolve-")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	baseFile := filepath.Join(tmpdir, "base.mod")
+	oursFile := filepath.Join(tmpdir, "ours.mod")
+	theirsFile := filepath.Join(tmpdir, "theirs.mod")
+
+	if err := gitutil.ShowToFile(mergeBase+":"+path, baseFile); err != nil {
+		os.WriteFile(baseFile, []byte("module unknown\n"), 0644)
+	}
+	if err := gitutil.ShowToFile("MERGE_HEAD:"+path, oursFile); err != nil {
+		return fmt.Errorf("cannot read MERGE_HEAD:%s — modify/delete conflict", path)
+	}
+	if err := gitutil.ShowToFile("HEAD:"+path, theirsFile); err != nil {
+		return fmt.Errorf("cannot read HEAD:%s — modify/delete conflict", path)
+	}
+
+	base, err := ParseFile(baseFile)
+	if err != nil {
+		return fmt.Errorf("parsing base: %w", err)
+	}
+	ours, err := ParseFile(oursFile)
+	if err != nil {
+		return fmt.Errorf("parsing ours: %w", err)
+	}
+	theirs, err := ParseFile(theirsFile)
+	if err != nil {
+		return fmt.Errorf("parsing theirs: %w", err)
+	}
+
+	merged, err := Merge(base, ours, theirs, goCeiling)
+	if err != nil {
+		return err
+	}
+
+	merged.Cleanup()
+	out, err := merged.Format()
+	if err != nil {
+		return fmt.Errorf("formatting: %w", err)
+	}
+	return os.WriteFile(path, out, 0644)
+}
+
+func ParseFile(path string) (*modfile.File, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lax := func(_, version string) (string, error) { return version, nil }
+	return modfile.Parse(path, data, lax)
+}
+
+func Merge(base, ours, theirs *modfile.File, goCeiling string) (*modfile.File, error) {
+	lax := func(_, v string) (string, error) { return v, nil }
+	result, err := modfile.Parse("merged", modfile.Format(ours.Syntax), lax)
+	if err != nil {
+		return nil, fmt.Errorf("copying ours: %w", err)
+	}
+
+	goVersion := mergeGoVersion(ours, theirs, goCeiling)
+	if err := result.AddGoStmt(goVersion); err != nil {
+		return nil, fmt.Errorf("setting go version: %w", err)
+	}
+
+	if err := mergeRequires(base, ours, theirs, result); err != nil {
+		return nil, fmt.Errorf("merging requires: %w", err)
+	}
+
+	mergeReplaces(base, ours, theirs, result)
+
+	return result, nil
+}
+
+func mergeGoVersion(ours, theirs *modfile.File, ceiling string) string {
+	oursVer := ""
+	if ours.Go != nil {
+		oursVer = ours.Go.Version
+	}
+	theirsVer := ""
+	if theirs.Go != nil {
+		theirsVer = theirs.Go.Version
+	}
+	return semver.ClampToMax(semver.Newer(oursVer, theirsVer), ceiling)
+}
+
+func mergeRequires(base, ours, theirs, result *modfile.File) error {
+	baseReqs := requireMap(base)
+	oursReqs := requireMap(ours)
+	theirsReqs := requireMap(theirs)
+
+	allPaths := make(map[string]bool)
+	for p := range oursReqs {
+		allPaths[p] = true
+	}
+	for p := range theirsReqs {
+		allPaths[p] = true
+	}
+
+	sorted := make([]string, 0, len(allPaths))
+	for p := range allPaths {
+		sorted = append(sorted, p)
+	}
+	sort.Strings(sorted)
+
+	indirectFlags := make(map[string]bool)
+
+	for _, path := range sorted {
+		baseReq := baseReqs[path]
+		oursReq := oursReqs[path]
+		theirsReq := theirsReqs[path]
+
+		baseVer := ""
+		if baseReq != nil {
+			baseVer = baseReq.Mod.Version
+		}
+
+		chosen := ResolveVersion(baseVer, oursReq, theirsReq)
+		if chosen == nil {
+			_ = result.DropRequire(path)
+			continue
+		}
+
+		if err := result.AddRequire(chosen.Mod.Path, chosen.Mod.Version); err != nil {
+			return fmt.Errorf("adding require %s: %w", path, err)
+		}
+		indirectFlags[path] = chosen.Indirect
+	}
+
+	for _, r := range result.Require {
+		if indirect, ok := indirectFlags[r.Mod.Path]; ok {
+			r.Indirect = indirect
+		}
+	}
+	result.SetRequireSeparateIndirect(result.Require)
+
+	return nil
+}
+
+func ResolveVersion(baseVer string, ours, theirs *modfile.Require) *modfile.Require {
+	if ours == nil && theirs == nil {
+		return nil
+	}
+	if ours == nil {
+		if theirs.Mod.Version == baseVer {
+			return nil
+		}
+		return theirs
+	}
+	if theirs == nil {
+		if ours.Mod.Version == baseVer {
+			return nil
+		}
+		return ours
+	}
+
+	if ours.Mod.Version == theirs.Mod.Version {
+		return ours
+	}
+
+	oursChanged := ours.Mod.Version != baseVer
+	theirsChanged := theirs.Mod.Version != baseVer
+
+	if oursChanged && !theirsChanged {
+		return ours
+	}
+	if !oursChanged && theirsChanged {
+		return theirs
+	}
+
+	if semver.Compare(ours.Mod.Version, theirs.Mod.Version) >= 0 {
+		return ours
+	}
+	return theirs
+}
+
+func mergeReplaces(base, ours, theirs, result *modfile.File) {
+	baseReplaces := replaceMap(base)
+	oursReplaces := replaceMap(ours)
+	theirsReplaces := replaceMap(theirs)
+
+	for path, rep := range theirsReplaces {
+		if _, exists := oursReplaces[path]; !exists {
+			result.AddReplace(rep.Old.Path, rep.Old.Version, rep.New.Path, rep.New.Version)
+		}
+	}
+
+	for path := range oursReplaces {
+		_, inBase := baseReplaces[path]
+		_, inTheirs := theirsReplaces[path]
+		if inBase && !inTheirs {
+			result.DropReplace(path, "")
+		}
+	}
+}
+
+func requireMap(f *modfile.File) map[string]*modfile.Require {
+	m := make(map[string]*modfile.Require, len(f.Require))
+	for _, r := range f.Require {
+		m[r.Mod.Path] = r
+	}
+	return m
+}
+
+func replaceMap(f *modfile.File) map[string]*modfile.Replace {
+	m := make(map[string]*modfile.Replace, len(f.Replace))
+	for _, r := range f.Replace {
+		m[r.Old.Path] = r
+	}
+	return m
+}

--- a/sync-upstream/resolve-conflicts/pkg/gomod/merge_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/gomod/merge_test.go
@@ -1,0 +1,116 @@
+package gomod
+
+import (
+	"testing"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+)
+
+func TestMergeGoVersion(t *testing.T) {
+	tests := []struct {
+		name, ours, theirs, ceiling, want string
+	}{
+		{"theirs newer within ceiling", "1.25.7", "1.26.2", "1.26.2", "1.26.2"},
+		{"theirs newer above ceiling", "1.25.7", "1.26.3", "1.26.2", "1.26.2"},
+		{"ours newer", "1.26.1", "1.25.0", "1.26.2", "1.26.1"},
+		{"no ceiling", "1.25.7", "1.26.3", "", "1.26.3"},
+		{"same version", "1.25.7", "1.25.7", "1.26.2", "1.25.7"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ours := goModWithVersion(t, tt.ours)
+			theirs := goModWithVersion(t, tt.theirs)
+			got := mergeGoVersion(ours, theirs, tt.ceiling)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name, baseVer, oursVer, theirsVer, wantVer string
+	}{
+		{"both changed, theirs newer", "v0.25.0", "v0.25.5", "v0.26.0", "v0.26.0"},
+		{"both changed, ours newer", "v0.25.0", "v0.27.0", "v0.26.0", "v0.27.0"},
+		{"only ours changed", "v0.25.0", "v0.26.0", "v0.25.0", "v0.26.0"},
+		{"only theirs changed", "v0.25.0", "v0.25.0", "v0.26.0", "v0.26.0"},
+		{"same version", "v1.0.0", "v1.0.0", "v1.0.0", "v1.0.0"},
+		{"date-based, ours newer", "v0.0.0-20210101000000-abc123", "v0.0.0-20241212093149-d2f9f4", "v0.0.0-20211028175153-1c139d", "v0.0.0-20241212093149-d2f9f4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ours := &modfile.Require{Mod: module.Version{Path: "example.com/dep", Version: tt.oursVer}}
+			theirs := &modfile.Require{Mod: module.Version{Path: "example.com/dep", Version: tt.theirsVer}}
+			got := ResolveVersion(tt.baseVer, ours, theirs)
+			if got == nil || got.Mod.Version != tt.wantVer {
+				t.Errorf("got %v, want %q", got, tt.wantVer)
+			}
+		})
+	}
+}
+
+func TestResolveVersionNil(t *testing.T) {
+	req := &modfile.Require{Mod: module.Version{Path: "example.com/dep", Version: "v1.0.0"}}
+	if got := ResolveVersion("", nil, req); got != req {
+		t.Error("expected theirs when ours is nil")
+	}
+	if got := ResolveVersion("", req, nil); got != req {
+		t.Error("expected ours when theirs is nil")
+	}
+	if got := ResolveVersion("", nil, nil); got != nil {
+		t.Error("expected nil when both nil")
+	}
+}
+
+func TestMergeIntegration(t *testing.T) {
+	lax := func(_, v string) (string, error) { return v, nil }
+	parse := func(s string) *modfile.File {
+		f, err := modfile.Parse("test", []byte(s), lax)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return f
+	}
+
+	base := parse("module test\n\ngo 1.25.0\n\nrequire (\n\tgithub.com/foo/bar v1.0.0\n\tgithub.com/shared/dep v0.5.0\n)\n")
+	ours := parse("module test\n\ngo 1.25.7\n\nrequire (\n\tgithub.com/foo/bar v1.1.0\n\tgithub.com/shared/dep v0.6.0\n\tgithub.com/downstream/only v1.0.0\n)\n")
+	theirs := parse("module test\n\ngo 1.26.3\n\nrequire (\n\tgithub.com/foo/bar v1.0.0\n\tgithub.com/shared/dep v0.7.0\n\tgithub.com/upstream/only v0.1.0\n)\n")
+
+	result, err := Merge(base, ours, theirs, "1.26.2")
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	if result.Go.Version != "1.26.2" {
+		t.Errorf("go version: %q, want 1.26.2", result.Go.Version)
+	}
+
+	reqs := requireMap(result)
+	check := func(path, want string) {
+		t.Helper()
+		r, ok := reqs[path]
+		if !ok {
+			t.Errorf("missing %s", path)
+			return
+		}
+		if r.Mod.Version != want {
+			t.Errorf("%s: got %q, want %q", path, r.Mod.Version, want)
+		}
+	}
+	check("github.com/foo/bar", "v1.1.0")
+	check("github.com/shared/dep", "v0.7.0")
+	check("github.com/downstream/only", "v1.0.0")
+	check("github.com/upstream/only", "v0.1.0")
+}
+
+func goModWithVersion(t *testing.T, version string) *modfile.File {
+	t.Helper()
+	f, err := modfile.Parse("go.mod", []byte("module test\n\ngo "+version+"\n"), nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return f
+}

--- a/sync-upstream/resolve-conflicts/pkg/pyxis/client.go
+++ b/sync-upstream/resolve-conflicts/pkg/pyxis/client.go
@@ -1,0 +1,84 @@
+package pyxis
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type label struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type imageData struct {
+	ParsedData struct {
+		Labels []label `json:"labels"`
+	} `json:"parsed_data"`
+}
+
+type apiResponse struct {
+	Data []imageData `json:"data"`
+}
+
+func GetGoVersion(imageRef string) (string, error) {
+	registry, repo, err := parseImageRef(imageRef)
+	if err != nil {
+		return "", err
+	}
+
+	encodedRepo := url.PathEscape(repo)
+	apiURL := fmt.Sprintf(
+		"https://catalog.redhat.com/api/containers/v1/repositories/registry/%s/repository/%s/images?filter=repositories.tags.name==latest&include=data.parsed_data.labels&page_size=1",
+		registry, encodedRepo,
+	)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(apiURL)
+	if err != nil {
+		return "", fmt.Errorf("pyxis API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("pyxis API returned %d", resp.StatusCode)
+	}
+
+	var result apiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+
+	if len(result.Data) == 0 {
+		return "", fmt.Errorf("no images found for %s", imageRef)
+	}
+
+	for _, l := range result.Data[0].ParsedData.Labels {
+		if l.Name == "version" {
+			return l.Value, nil
+		}
+	}
+
+	return "", fmt.Errorf("no version label found for %s", imageRef)
+}
+
+func parseImageRef(ref string) (registry, repo string, err error) {
+	ref = strings.TrimPrefix(ref, "docker://")
+
+	// registry.redhat.io/ubi9/go-toolset:tag -> registry=registry.access.redhat.com repo=ubi9/go-toolset
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid image reference: %s", ref)
+	}
+
+	repo = parts[1]
+	if idx := strings.LastIndex(repo, ":"); idx != -1 {
+		repo = repo[:idx]
+	}
+
+	registry = "registry.access.redhat.com"
+	return registry, repo, nil
+}

--- a/sync-upstream/resolve-conflicts/pkg/pyxis/client_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/pyxis/client_test.go
@@ -1,0 +1,26 @@
+package pyxis
+
+import "testing"
+
+func TestParseImageRef(t *testing.T) {
+	tests := []struct {
+		ref      string
+		wantRepo string
+	}{
+		{"registry.redhat.io/ubi9/go-toolset:latest", "ubi9/go-toolset"},
+		{"registry.redhat.io/ubi9/go-toolset", "ubi9/go-toolset"},
+		{"docker://registry.redhat.io/ubi9/go-toolset:latest", "ubi9/go-toolset"},
+		{"registry.redhat.io/ubi9/go-toolset:1.21", "ubi9/go-toolset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			_, repo, err := parseImageRef(tt.ref)
+			if err != nil {
+				t.Fatalf("parseImageRef: %v", err)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo: got %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/sync-upstream/resolve-conflicts/pkg/semver/semver.go
+++ b/sync-upstream/resolve-conflicts/pkg/semver/semver.go
@@ -1,0 +1,35 @@
+package semver
+
+import (
+	"strings"
+
+	modsemver "golang.org/x/mod/semver"
+)
+
+func Compare(a, b string) int {
+	return modsemver.Compare(Canonical(a), Canonical(b))
+}
+
+func Canonical(v string) string {
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	return v
+}
+
+func Newer(a, b string) string {
+	if Compare(a, b) >= 0 {
+		return a
+	}
+	return b
+}
+
+func ClampToMax(version, ceiling string) string {
+	if ceiling == "" {
+		return version
+	}
+	if Compare(version, ceiling) > 0 {
+		return ceiling
+	}
+	return version
+}

--- a/sync-upstream/resolve-conflicts/pkg/semver/semver_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/semver/semver_test.go
@@ -1,0 +1,43 @@
+package semver
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.0.0", "v1.0.0", 0},
+		{"v1.1.0", "v1.0.0", 1},
+		{"v1.0.0", "v1.1.0", -1},
+		{"1.26.3", "1.26.2", 1},
+		{"1.25.7", "1.26.3", -1},
+	}
+	for _, tt := range tests {
+		got := Compare(tt.a, tt.b)
+		if (tt.want > 0 && got <= 0) || (tt.want < 0 && got >= 0) || (tt.want == 0 && got != 0) {
+			t.Errorf("Compare(%q, %q) = %d, want sign %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestNewer(t *testing.T) {
+	if got := Newer("1.26.3", "1.25.7"); got != "1.26.3" {
+		t.Errorf("got %q, want 1.26.3", got)
+	}
+	if got := Newer("1.25.7", "1.26.3"); got != "1.26.3" {
+		t.Errorf("got %q, want 1.26.3", got)
+	}
+}
+
+func TestClampToMax(t *testing.T) {
+	if got := ClampToMax("1.26.3", "1.26.2"); got != "1.26.2" {
+		t.Errorf("got %q, want 1.26.2 (clamped)", got)
+	}
+	if got := ClampToMax("1.25.7", "1.26.2"); got != "1.25.7" {
+		t.Errorf("got %q, want 1.25.7 (under ceiling)", got)
+	}
+	if got := ClampToMax("1.26.3", ""); got != "1.26.3" {
+		t.Errorf("got %q, want 1.26.3 (no ceiling)", got)
+	}
+}

--- a/sync-upstream/resolve-conflicts/pkg/workflow/resolve.go
+++ b/sync-upstream/resolve-conflicts/pkg/workflow/resolve.go
@@ -1,0 +1,110 @@
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/conflict"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gitutil"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/semver"
+)
+
+var (
+	usesRe    = regexp.MustCompile(`uses:\s+\S+`)
+	versionRe = regexp.MustCompile(`#\s*v([0-9]+\.[0-9]+(?:\.[0-9]+)?)`)
+)
+
+func IsMatch(path string) bool {
+	return strings.HasPrefix(path, ".github/workflows/") &&
+		(strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml"))
+}
+
+func ResolveAll() (resolved, failed []string, err error) {
+	files, err := gitutil.ConflictingFiles()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, f := range files {
+		if !IsMatch(f) {
+			continue
+		}
+		if err := Resolve(f); err != nil {
+			fmt.Printf("  SKIP %s (workflow: %v)\n", f, err)
+			failed = append(failed, f)
+		} else {
+			fmt.Printf("  OK   %s (workflow)\n", f)
+			if err := gitutil.Add(f); err != nil {
+				fmt.Printf("  WARN %s: %v\n", f, err)
+			}
+			resolved = append(resolved, f)
+		}
+	}
+	return
+}
+
+func IsActionBump(block conflict.Block) bool {
+	for _, side := range []string{block.Ours, block.Theirs} {
+		for _, line := range strings.Split(side, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if !usesRe.MatchString(line) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func ResolveActionBump(block conflict.Block) string {
+	oursVer := extractVersion(block.Ours)
+	theirsVer := extractVersion(block.Theirs)
+
+	if oursVer == "" || theirsVer == "" {
+		return block.Ours
+	}
+
+	if semver.Compare(oursVer, theirsVer) >= 0 {
+		return block.Ours
+	}
+	return block.Theirs
+}
+
+func Resolve(inputPath string) error {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	f, err := conflict.Parse(strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("parsing conflicts: %w", err)
+	}
+
+	if !f.HasConflicts() {
+		return nil
+	}
+
+	for _, block := range f.Conflicts() {
+		if !IsActionBump(block) {
+			return fmt.Errorf("non-action-bump conflict found, cannot auto-resolve")
+		}
+		if extractVersion(block.Ours) == "" || extractVersion(block.Theirs) == "" {
+			return fmt.Errorf("cannot extract action version from conflict block, resolve manually")
+		}
+	}
+
+	resolved := f.Render(ResolveActionBump)
+	return os.WriteFile(inputPath, []byte(resolved), 0644)
+}
+
+func extractVersion(s string) string {
+	m := versionRe.FindStringSubmatch(s)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}

--- a/sync-upstream/resolve-conflicts/pkg/workflow/resolve_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/workflow/resolve_test.go
@@ -1,0 +1,125 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/conflict"
+)
+
+func TestIsActionBump(t *testing.T) {
+	tests := []struct {
+		name  string
+		block conflict.Block
+		want  bool
+	}{
+		{
+			"action bump",
+			conflict.Block{
+				Ours:   "      - uses: actions/setup-go@aaa # v6.4.0",
+				Theirs: "      - uses: actions/setup-go@bbb # v6.3.0",
+			},
+			true,
+		},
+		{
+			"non-action line",
+			conflict.Block{
+				Ours:   "      run: echo hello",
+				Theirs: "      run: echo world",
+			},
+			false,
+		},
+		{
+			"mixed",
+			conflict.Block{
+				Ours:   "      - uses: actions/setup-go@aaa # v6.4.0\n      run: echo hi",
+				Theirs: "      - uses: actions/setup-go@bbb # v6.3.0",
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsActionBump(tt.block); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveActionBump(t *testing.T) {
+	block := conflict.Block{
+		Ours:   "      - uses: actions/setup-go@aaa111 # v6.4.0",
+		Theirs: "      - uses: actions/setup-go@bbb222 # v6.3.0",
+	}
+
+	got := ResolveActionBump(block)
+	if !strings.Contains(got, "v6.4.0") {
+		t.Errorf("expected v6.4.0 (newer), got %q", got)
+	}
+}
+
+func TestResolveActionBumpTheirsNewer(t *testing.T) {
+	block := conflict.Block{
+		Ours:   "      - uses: codecov/codecov-action@aaa # v5.5.2",
+		Theirs: "      - uses: codecov/codecov-action@bbb # v6.0.0",
+	}
+
+	got := ResolveActionBump(block)
+	if !strings.Contains(got, "v6.0.0") {
+		t.Errorf("expected v6.0.0 (newer), got %q", got)
+	}
+}
+
+func TestResolveFile(t *testing.T) {
+	input := `name: CI
+on: push
+jobs:
+  test:
+    steps:
+<<<<<<< HEAD
+      - uses: actions/setup-go@aaa111 # v6.4.0
+=======
+      - uses: actions/setup-go@bbb222 # v6.3.0
+>>>>>>> origin/main
+      - run: go test ./...
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "workflow.yml")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("conflict markers remain")
+	}
+	if !strings.Contains(string(got), "v6.4.0") {
+		t.Error("expected v6.4.0 in output")
+	}
+	if !strings.Contains(string(got), "go test") {
+		t.Error("non-conflict content missing")
+	}
+}
+
+func TestResolveFileNonActionConflict(t *testing.T) {
+	input := `<<<<<<< HEAD
+      run: echo hello
+=======
+      run: echo world
+>>>>>>> origin/main
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "workflow.yml")
+	os.WriteFile(file, []byte(input), 0644)
+
+	err := Resolve(file)
+	if err == nil {
+		t.Error("expected error for non-action conflict")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a Go CLI tool (`resolve-conflicts`) with 4 subcommands that handle known merge conflict patterns during upstream syncs
- Adds a thin bash orchestrator (`resolve-conflicts.sh`) that handles git operations and delegates resolution to the Go tool
- Integrates into the existing `sync-upstream` composite action with new inputs for configuration

### Conflict patterns handled automatically

| Pattern | Resolver | Logic |
|---------|----------|-------|
| Dockerfile `FROM` version conflicts | `resolve-conflicts dockerfile` | Picks the side with the newer image version (any image, not just golang) |
| `go.mod` three-way merge | `resolve-conflicts gomod` | Takes newest semver per dep, clamps `go` directive to ubi9/go-toolset ceiling |
| GitHub Actions version bumps | `resolve-conflicts workflow` | Picks newer `uses: action@SHA # vX.Y.Z` for each conflict block |
| Go version ceiling detection | `resolve-conflicts go-ceiling` | Queries Red Hat Pyxis API for ubi9/go-toolset version label |
| Downstream-only files | bash (git operations) | Auto-detects files added only downstream and restores them |
| `go.sum` conflicts | bash (cleanup) | Removes conflicted go.sum before `go mod tidy` regenerates it |

### New action inputs

| Input | Default | Purpose |
|-------|---------|---------|
| `resolve_conflicts` | `true` | Enable/disable auto-resolution |
| `go_version_ceiling_image` | `registry.redhat.io/ubi9/go-toolset:latest` | Image to query for max Go version |
| `go_version_ceiling` | (empty) | Explicit override, skips Pyxis API |
| `downstream_only_files` | (empty) | Extra files to always restore from main |

### Go package structure

```
resolve-conflicts/
  main.go              # CLI entry point (subcommand dispatch, no deps)
  cmd/                 # Thin subcommand wrappers
  pkg/
    semver/            # Shared version comparison utilities
    conflict/          # Git conflict marker parser
    gomod/             # Three-way go.mod merge (golang.org/x/mod)
    dockerfile/        # Dockerfile FROM version resolution
    workflow/          # Workflow action version bump resolution
    pyxis/             # Red Hat Pyxis API client
```

## Test plan

- [x] All 6 Go packages pass unit tests (`go test ./...`)
- [x] End-to-end tested against securesign/rekor PR #629 (v1.5.2 upstream sync) — all 8 real conflicts resolved automatically
- [x] Verify action works in CI by triggering a sync on a test repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)