### PR TITLE
Add FIPS-aware conflict resolver for upstream syncs

### DIFF
--- a/sync-upstream/resolve-conflicts.sh
+++ b/sync-upstream/resolve-conflicts.sh
@@ -92,6 +92,12 @@ restore_downstream_only_files() {
     echo "::endgroup::"
 }
 
+resolve_fips() {
+    echo "::group::Resolving FIPS-related conflicts"
+    "${RESOLVE}" fips || true
+    echo "::endgroup::"
+}
+
 resolve_image_versions() {
     echo "::group::Resolving image version conflicts"
     local conflicts
@@ -269,6 +275,7 @@ main() {
         go_ceiling=$(get_go_ceiling)
         info "Go version ceiling: ${go_ceiling}"
 
+        resolve_fips
         resolve_image_versions
         resolve_gomod "${go_ceiling}"
         resolve_workflows

--- a/sync-upstream/resolve-conflicts/cmd/fips.go
+++ b/sync-upstream/resolve-conflicts/cmd/fips.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/fips"
+)
+
+func Fips(args []string) {
+	resolved, partial, failed, err := fips.ResolveAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fips: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("\n[fips] Resolved: %d, Partial: %d, Failed: %d\n", len(resolved), len(partial), len(failed))
+	if len(failed) > 0 {
+		fmt.Println("Failed (resolve manually):")
+		for _, f := range failed {
+			fmt.Printf("  %s\n", f)
+		}
+	}
+}

--- a/sync-upstream/resolve-conflicts/cmd/run.go
+++ b/sync-upstream/resolve-conflicts/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/dockerfile"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/fips"
 	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gomod"
 	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/workflow"
 )
@@ -16,6 +17,14 @@ func Run(args []string) {
 	fs.Parse(args)
 
 	var allResolved, allFailed []string
+
+	fr, _, ff, err := fips.ResolveAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fips: %v\n", err)
+		os.Exit(1)
+	}
+	allResolved = append(allResolved, fr...)
+	allFailed = append(allFailed, ff...)
 
 	r, f, err := dockerfile.ResolveAll()
 	if err != nil {

--- a/sync-upstream/resolve-conflicts/main.go
+++ b/sync-upstream/resolve-conflicts/main.go
@@ -21,6 +21,8 @@ func main() {
 		cmd.Dockerfile(os.Args[2:])
 	case "workflow":
 		cmd.Workflow(os.Args[2:])
+	case "fips":
+		cmd.Fips(os.Args[2:])
 	case "go-ceiling":
 		cmd.GoCeiling(os.Args[2:])
 	default:
@@ -35,6 +37,7 @@ Usage: resolve-conflicts <command> [flags]
 
 Commands:
   all         Auto-resolve all known conflict patterns in the current merge
+  fips        Resolve conflicts in blocks marked with RHTAS FIPS banners
   gomod       Three-way merge of go.mod files
   dockerfile  Resolve Dockerfile golang version conflicts
   workflow    Resolve GitHub Actions workflow version conflicts

--- a/sync-upstream/resolve-conflicts/pkg/conflict/parser.go
+++ b/sync-upstream/resolve-conflicts/pkg/conflict/parser.go
@@ -7,8 +7,24 @@ import (
 )
 
 type Block struct {
-	Ours   string
-	Theirs string
+	Ours       string
+	Theirs     string
+	OursLabel  string
+	TheirsLabel string
+}
+
+func (b Block) ReEmit() string {
+	var out strings.Builder
+	out.WriteString("<<<<<<< " + b.OursLabel)
+	if b.Ours != "" {
+		out.WriteString("\n" + b.Ours)
+	}
+	out.WriteString("\n=======")
+	if b.Theirs != "" {
+		out.WriteString("\n" + b.Theirs)
+	}
+	out.WriteString("\n>>>>>>> " + b.TheirsLabel)
+	return out.String()
 }
 
 type File struct {
@@ -26,6 +42,7 @@ func Parse(r io.Reader) (*File, error) {
 	var f File
 	var current strings.Builder
 	var ours, theirs strings.Builder
+	var oursLabel, theirsLabel string
 	inOurs, inTheirs := false, false
 	currentHasLines := false
 
@@ -39,6 +56,7 @@ func Parse(r io.Reader) (*File, error) {
 			currentHasLines = false
 			ours.Reset()
 			theirs.Reset()
+			oursLabel = strings.TrimPrefix(line, "<<<<<<< ")
 			inOurs = true
 			inTheirs = false
 
@@ -47,8 +65,14 @@ func Parse(r io.Reader) (*File, error) {
 			inTheirs = true
 
 		case strings.HasPrefix(line, ">>>>>>> ") && inTheirs:
+			theirsLabel = strings.TrimPrefix(line, ">>>>>>> ")
 			f.Sections = append(f.Sections, Section{
-				Conflict: &Block{Ours: ours.String(), Theirs: theirs.String()},
+				Conflict: &Block{
+					Ours:        ours.String(),
+					Theirs:      theirs.String(),
+					OursLabel:   oursLabel,
+					TheirsLabel: theirsLabel,
+				},
 			})
 			inOurs = false
 			inTheirs = false

--- a/sync-upstream/resolve-conflicts/pkg/conflict/parser_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/conflict/parser_test.go
@@ -100,6 +100,76 @@ after`
 	}
 }
 
+func TestLabels(t *testing.T) {
+	input := `before
+<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> origin/main
+after`
+
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	block := f.Conflicts()[0]
+	if block.OursLabel != "HEAD" {
+		t.Errorf("OursLabel: got %q, want %q", block.OursLabel, "HEAD")
+	}
+	if block.TheirsLabel != "origin/main" {
+		t.Errorf("TheirsLabel: got %q, want %q", block.TheirsLabel, "origin/main")
+	}
+}
+
+func TestReEmit(t *testing.T) {
+	input := `before
+<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> origin/main
+after`
+
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	got := f.Render(func(b Block) string {
+		return b.ReEmit()
+	})
+
+	want := "before\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\nafter\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReEmitEmptySide(t *testing.T) {
+	input := "<<<<<<< HEAD\n=======\ntheirs only\n>>>>>>> origin/main\n"
+
+	f, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	block := f.Conflicts()[0]
+	if block.Ours != "" {
+		t.Errorf("Ours should be empty, got %q", block.Ours)
+	}
+
+	got := f.Render(func(b Block) string {
+		return b.ReEmit()
+	})
+
+	want := "<<<<<<< HEAD\n=======\ntheirs only\n>>>>>>> origin/main\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestNoConflicts(t *testing.T) {
 	input := "line 1\nline 2\nline 3"
 	f, err := Parse(strings.NewReader(input))

--- a/sync-upstream/resolve-conflicts/pkg/fips/resolve.go
+++ b/sync-upstream/resolve-conflicts/pkg/fips/resolve.go
@@ -1,0 +1,87 @@
+package fips
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/conflict"
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/gitutil"
+)
+
+const Marker = "RHTAS FIPS - DO NOT REMOVE"
+
+func IsFIPSConflict(block conflict.Block) bool {
+	return strings.Contains(block.Ours, Marker) || strings.Contains(block.Theirs, Marker)
+}
+
+func ResolveAll() (resolved, partiallyResolved, failed []string, err error) {
+	files, err := gitutil.ConflictingFiles()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	for _, f := range files {
+		hasFIPS, fullyResolved, resolveErr := Resolve(f)
+		if !hasFIPS {
+			continue
+		}
+		if resolveErr != nil {
+			fmt.Printf("  SKIP %s (fips: %v)\n", f, resolveErr)
+			failed = append(failed, f)
+			continue
+		}
+		if fullyResolved {
+			fmt.Printf("  OK   %s (fips)\n", f)
+			if err := gitutil.Add(f); err != nil {
+				fmt.Printf("  WARN %s: %v\n", f, err)
+			}
+			resolved = append(resolved, f)
+		} else {
+			fmt.Printf("  PARTIAL %s (fips: non-FIPS conflicts remain)\n", f)
+			partiallyResolved = append(partiallyResolved, f)
+		}
+	}
+	return
+}
+
+// Resolve processes a single file. It returns whether the file contained FIPS
+// conflicts and whether all conflicts were resolved.
+func Resolve(path string) (hasFIPS, fullyResolved bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, false, fmt.Errorf("reading file: %w", err)
+	}
+
+	f, err := conflict.Parse(strings.NewReader(string(data)))
+	if err != nil {
+		return false, false, fmt.Errorf("parsing conflicts: %w", err)
+	}
+
+	if !f.HasConflicts() {
+		return false, false, nil
+	}
+
+	fipsCount := 0
+	for _, block := range f.Conflicts() {
+		if IsFIPSConflict(block) {
+			fipsCount++
+		}
+	}
+	if fipsCount == 0 {
+		return false, false, nil
+	}
+
+	rendered := f.Render(func(block conflict.Block) string {
+		if IsFIPSConflict(block) {
+			return block.Theirs
+		}
+		return block.ReEmit()
+	})
+
+	if err := os.WriteFile(path, []byte(rendered), 0644); err != nil {
+		return true, false, fmt.Errorf("writing file: %w", err)
+	}
+
+	fullyResolved = fipsCount == len(f.Conflicts())
+	return true, fullyResolved, nil
+}

--- a/sync-upstream/resolve-conflicts/pkg/fips/resolve_test.go
+++ b/sync-upstream/resolve-conflicts/pkg/fips/resolve_test.go
@@ -1,0 +1,232 @@
+package fips
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/securesign/actions/sync-upstream/resolve-conflicts/pkg/conflict"
+)
+
+func TestIsFIPSConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		block conflict.Block
+		want  bool
+	}{
+		{
+			name: "full banner in theirs",
+			block: conflict.Block{
+				Ours: "upstream code",
+				Theirs: `// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+crypto/fips140.Enabled()
+// ========================================`,
+			},
+			want: true,
+		},
+		{
+			name: "bare comment in theirs",
+			block: conflict.Block{
+				Ours:   "upstream code",
+				Theirs: "// RHTAS FIPS - DO NOT REMOVE\nsome fips code",
+			},
+			want: true,
+		},
+		{
+			name: "marker in ours",
+			block: conflict.Block{
+				Ours:   "// RHTAS FIPS - DO NOT REMOVE\nsome code",
+				Theirs: "other code",
+			},
+			want: true,
+		},
+		{
+			name: "no marker",
+			block: conflict.Block{
+				Ours:   "upstream code",
+				Theirs: "downstream code",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsFIPSConflict(tt.block); got != tt.want {
+				t.Errorf("IsFIPSConflict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolve_AllFIPS(t *testing.T) {
+	input := `package main
+
+<<<<<<< HEAD
+func doStuff() {
+	hash := sha256.Sum256(data)
+}
+=======
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+func doStuff() {
+	if fips140.Enabled() {
+		hash := sha256.Sum256(data)
+	}
+}
+// ========================================
+>>>>>>> origin/downstream
+`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	os.WriteFile(file, []byte(input), 0644)
+
+	hasFIPS, fullyResolved, err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !hasFIPS {
+		t.Error("expected hasFIPS=true")
+	}
+	if !fullyResolved {
+		t.Error("expected fullyResolved=true")
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("output still contains conflict markers")
+	}
+	if !strings.Contains(string(got), "RHTAS FIPS - DO NOT REMOVE") {
+		t.Error("output missing FIPS marker")
+	}
+	if !strings.Contains(string(got), "fips140.Enabled()") {
+		t.Error("output missing FIPS code")
+	}
+}
+
+func TestResolve_MixedConflicts(t *testing.T) {
+	input := `package main
+
+<<<<<<< HEAD
+func doStuff() {
+	hash := sha256.Sum256(data)
+}
+=======
+// RHTAS FIPS - DO NOT REMOVE
+func doStuff() {
+	if fips140.Enabled() {
+		hash := sha256.Sum256(data)
+	}
+}
+>>>>>>> origin/downstream
+middle section
+<<<<<<< HEAD
+FROM golang:1.22
+=======
+FROM golang:1.21
+>>>>>>> origin/downstream
+end`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "mixed.go")
+	os.WriteFile(file, []byte(input), 0644)
+
+	hasFIPS, fullyResolved, err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !hasFIPS {
+		t.Error("expected hasFIPS=true")
+	}
+	if fullyResolved {
+		t.Error("expected fullyResolved=false for mixed conflicts")
+	}
+
+	got, _ := os.ReadFile(file)
+	if !strings.Contains(string(got), "RHTAS FIPS - DO NOT REMOVE") {
+		t.Error("FIPS block should be resolved (downstream taken)")
+	}
+	if !strings.Contains(string(got), "<<<<<<< HEAD") {
+		t.Error("non-FIPS conflict should still have markers")
+	}
+	if !strings.Contains(string(got), "FROM golang:1.22") {
+		t.Error("non-FIPS ours side should be preserved in markers")
+	}
+	if !strings.Contains(string(got), "FROM golang:1.21") {
+		t.Error("non-FIPS theirs side should be preserved in markers")
+	}
+}
+
+func TestResolve_NoFIPS(t *testing.T) {
+	input := `before
+<<<<<<< HEAD
+upstream change
+=======
+downstream change
+>>>>>>> origin/downstream
+after`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "nofips.txt")
+	os.WriteFile(file, []byte(input), 0644)
+
+	hasFIPS, _, err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if hasFIPS {
+		t.Error("expected hasFIPS=false")
+	}
+}
+
+func TestResolve_NoConflicts(t *testing.T) {
+	input := "clean file\nno conflicts\n"
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "clean.go")
+	os.WriteFile(file, []byte(input), 0644)
+
+	hasFIPS, _, err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if hasFIPS {
+		t.Error("expected hasFIPS=false for clean file")
+	}
+}
+
+func TestResolve_BareComment(t *testing.T) {
+	input := `before
+<<<<<<< HEAD
+original line
+=======
+original line
+// RHTAS FIPS - DO NOT REMOVE
+>>>>>>> origin/downstream
+after`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "bare.go")
+	os.WriteFile(file, []byte(input), 0644)
+
+	hasFIPS, fullyResolved, err := Resolve(file)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !hasFIPS {
+		t.Error("expected hasFIPS=true")
+	}
+	if !fullyResolved {
+		t.Error("expected fullyResolved=true")
+	}
+
+	got, _ := os.ReadFile(file)
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Error("output still contains conflict markers")
+	}
+	if !strings.Contains(string(got), "RHTAS FIPS - DO NOT REMOVE") {
+		t.Error("output missing bare FIPS comment")
+	}
+}


### PR DESCRIPTION
- Adds a new fips resolver that automatically resolves merge conflicts in blocks marked with // RHTAS FIPS - DO NOT REMOVE banners by taking the downstream side
- Supports partial resolution — FIPS blocks are resolved while non-FIPS conflicts in the same file are left for subsequent resolvers (dockerfile, gomod, workflow)
- Extends the conflict parser with label capture and ReEmit() to preserve valid conflict markers for unresolved blocks
- Runs first in the resolver pipeline to maximize downstream resolver coverage